### PR TITLE
feat: fetch executor operator peering data

### DIFF
--- a/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher.go
+++ b/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher.go
@@ -2,9 +2,9 @@ package peeringDataFetcher
 
 import (
 	"context"
+	"fmt"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/contractCaller"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/peering"
-	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/util"
 	"go.uber.org/zap"
 )
 
@@ -29,8 +29,28 @@ func (pdf *PeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAdd
 		pdf.logger.Sugar().Errorf("Failed to get AVS config", zap.Error(err))
 		return nil, err
 	}
-	operatorPeeringInfos := pdf.groupOperatorPeeringAcrossOpSets(avsAddress, avsConfig)
-	return reduceOperatorPeers(operatorPeeringInfos), nil
+	operatorPeeringInfos := map[string]*peering.OperatorPeerInfo{}
+	for _, operatorSetId := range avsConfig.ExecutorOperatorSetIds {
+		peeringInfos, err := pdf.contractCaller.GetOperatorSetMembersWithPeering(avsAddress, operatorSetId)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get operator set members with peering %w", err)
+		}
+		for _, peeringInfo := range peeringInfos {
+			infos, ok := operatorPeeringInfos[peeringInfo.OperatorAddress]
+			if !ok {
+				operatorPeeringInfos[peeringInfo.OperatorAddress] = peeringInfo
+				continue
+			}
+			infos.OperatorSetIds = append(infos.OperatorSetIds, peeringInfo.OperatorSetIds...)
+		}
+
+	}
+	result := make([]*peering.OperatorPeerInfo, 0, len(operatorPeeringInfos))
+	for _, info := range operatorPeeringInfos {
+		result = append(result, info)
+	}
+
+	return result, nil
 }
 
 func (pdf *PeeringDataFetcher) ListAggregatorOperators(ctx context.Context, avsAddress string) ([]*peering.OperatorPeerInfo, error) {
@@ -46,43 +66,4 @@ func (pdf *PeeringDataFetcher) ListAggregatorOperators(ctx context.Context, avsA
 	}
 
 	return pdf.contractCaller.GetOperatorSetMembersWithPeering(avsAddress, avsConfig.AggregatorOperatorSetId)
-}
-
-func (pdf *PeeringDataFetcher) groupOperatorPeeringAcrossOpSets(
-	avsAddress string,
-	avsConfig *contractCaller.AVSConfig,
-) map[string][]*peering.OperatorPeerInfo {
-	operatorPeeringInfos := map[string][]*peering.OperatorPeerInfo{}
-	for _, operatorSetId := range avsConfig.ExecutorOperatorSetIds {
-		peeringInfos, err := pdf.contractCaller.GetOperatorSetMembersWithPeering(avsAddress, operatorSetId)
-		if err != nil {
-			return nil
-		}
-		for _, peeringInfo := range peeringInfos {
-			infos, ok := operatorPeeringInfos[peeringInfo.OperatorAddress]
-			if !ok {
-				infos = []*peering.OperatorPeerInfo{}
-				infos = append(infos, peeringInfo)
-				operatorPeeringInfos[peeringInfo.OperatorAddress] = infos
-			} else {
-				operatorPeeringInfos[peeringInfo.OperatorAddress] = append(infos, peeringInfo)
-			}
-		}
-
-	}
-	return operatorPeeringInfos
-}
-
-func reduceOperatorPeers(operatorPeeringInfos map[string][]*peering.OperatorPeerInfo) []*peering.OperatorPeerInfo {
-	result := make([]*peering.OperatorPeerInfo, 0, len(operatorPeeringInfos))
-	for _, peeringInfos := range operatorPeeringInfos {
-		operatorSetIds := util.Reduce(peeringInfos, func(operatorSetIds []uint32, next *peering.OperatorPeerInfo) []uint32 {
-			return append(operatorSetIds, next.OperatorSetIds...)
-		}, []uint32{})
-
-		merged := *peeringInfos[0]
-		merged.OperatorSetIds = operatorSetIds
-		result = append(result, &merged)
-	}
-	return result
 }


### PR DESCRIPTION
## Overview
Using ChainCaller to fetch executor operator peering data. This is used to inform the ExecutionManager which operators it should be able to distributed work to.

### TODO
 - Support querying by block.