### PR TITLE
feat: ecdsa certificate verifier

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -26,6 +26,12 @@ optimizer = true
 # and code execution cost (cost after deployment).
 optimizer_runs = 200
 
+# An array of file paths from which warnings should be ignored during compilation.
+ignored_warnings_from = [
+    "test",
+    "lib"
+]
+
 [rpc_endpoints]
 mainnet = "${RPC_MAINNET}"
 holesky = "${RPC_HOLESKY}"

--- a/contracts/script/local/DeployTaskMailbox.s.sol
+++ b/contracts/script/local/DeployTaskMailbox.s.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.27;
 import {Script, console} from "forge-std/Script.sol";
 
 import {TaskMailbox} from "../../src/core/TaskMailbox.sol";
+import {ITaskMailboxTypes} from "../../src/interfaces/core/ITaskMailbox.sol";
 
 contract DeployTaskMailbox is Script {
     function setUp() public {}
@@ -17,7 +18,12 @@ contract DeployTaskMailbox is Script {
         vm.startBroadcast(deployerPrivateKey);
         console.log("Deployer address:", deployer);
 
-        TaskMailbox taskMailbox = new TaskMailbox();
+        // For now, deploy with empty certificate verifiers array
+        // The owner can set them later using setCertificateVerifier
+        ITaskMailboxTypes.CertificateVerifierConfig[] memory certificateVerifiers =
+            new ITaskMailboxTypes.CertificateVerifierConfig[](0);
+
+        TaskMailbox taskMailbox = new TaskMailbox(deployer, certificateVerifiers);
         console.log("TaskMailbox deployed to:", address(taskMailbox));
 
         vm.stopBroadcast();

--- a/contracts/script/local/DeployTaskMailbox.s.sol
+++ b/contracts/script/local/DeployTaskMailbox.s.sol
@@ -9,8 +9,8 @@ import {ITaskMailboxTypes} from "../../src/interfaces/core/ITaskMailbox.sol";
 
 contract DeployTaskMailbox is Script {
     // Eigenlayer Core Contracts
-    address public BN254_CERTIFICATE_VERIFIER = 0x0E3a2eAd8f63A196391a7D46083d3f2b1925C2b3;
-    address public ECDSA_CERTIFICATE_VERIFIER = 0xfB7d94501E4d4ACC264833Ef4ede70a11517422B;
+    address public BN254_CERTIFICATE_VERIFIER = 0x824604a31b580Aec16D8Dd7ae9A27661Dc65cBA3;
+    address public ECDSA_CERTIFICATE_VERIFIER = 0x95A49cB0aED0e8f299223Da3A8A335440f5F00E7;
 
     function setUp() public {}
 

--- a/contracts/script/local/DeployTaskMailbox.s.sol
+++ b/contracts/script/local/DeployTaskMailbox.s.sol
@@ -9,8 +9,8 @@ import {ITaskMailboxTypes} from "../../src/interfaces/core/ITaskMailbox.sol";
 
 contract DeployTaskMailbox is Script {
     // Eigenlayer Core Contracts
-    address public BN254_CERTIFICATE_VERIFIER = 0xf462d03A82C1F3496B0DFe27E978318eD1720E1f;
-    address public ECDSA_CERTIFICATE_VERIFIER = 0xF9BDd6af3Fb02659101cbb776DC7cb4879c93d8A;
+    address public BN254_CERTIFICATE_VERIFIER = 0x0E3a2eAd8f63A196391a7D46083d3f2b1925C2b3;
+    address public ECDSA_CERTIFICATE_VERIFIER = 0xfB7d94501E4d4ACC264833Ef4ede70a11517422B;
 
     function setUp() public {}
 

--- a/contracts/script/local/DeployTaskMailbox.s.sol
+++ b/contracts/script/local/DeployTaskMailbox.s.sol
@@ -4,9 +4,14 @@ pragma solidity ^0.8.27;
 import {Script, console} from "forge-std/Script.sol";
 
 import {TaskMailbox} from "../../src/core/TaskMailbox.sol";
+import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 import {ITaskMailboxTypes} from "../../src/interfaces/core/ITaskMailbox.sol";
 
 contract DeployTaskMailbox is Script {
+    // Eigenlayer Core Contracts
+    address public BN254_CERTIFICATE_VERIFIER = 0xf462d03A82C1F3496B0DFe27E978318eD1720E1f;
+    address public ECDSA_CERTIFICATE_VERIFIER = 0xF9BDd6af3Fb02659101cbb776DC7cb4879c93d8A;
+
     function setUp() public {}
 
     function run() public {
@@ -18,10 +23,16 @@ contract DeployTaskMailbox is Script {
         vm.startBroadcast(deployerPrivateKey);
         console.log("Deployer address:", deployer);
 
-        // For now, deploy with empty certificate verifiers array
-        // The owner can set them later using setCertificateVerifier
         ITaskMailboxTypes.CertificateVerifierConfig[] memory certificateVerifiers =
-            new ITaskMailboxTypes.CertificateVerifierConfig[](0);
+            new ITaskMailboxTypes.CertificateVerifierConfig[](2);
+        certificateVerifiers[0] = ITaskMailboxTypes.CertificateVerifierConfig({
+            curveType: IKeyRegistrarTypes.CurveType.BN254,
+            verifier: BN254_CERTIFICATE_VERIFIER
+        });
+        certificateVerifiers[1] = ITaskMailboxTypes.CertificateVerifierConfig({
+            curveType: IKeyRegistrarTypes.CurveType.ECDSA,
+            verifier: ECDSA_CERTIFICATE_VERIFIER
+        });
 
         TaskMailbox taskMailbox = new TaskMailbox(deployer, certificateVerifiers);
         console.log("TaskMailbox deployed to:", address(taskMailbox));

--- a/contracts/script/local/SetupAVSTaskMailboxConfig.s.sol
+++ b/contracts/script/local/SetupAVSTaskMailboxConfig.s.sol
@@ -5,6 +5,7 @@ import {Script, console} from "forge-std/Script.sol";
 
 import {OperatorSet, OperatorSetLib} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 
 import {ITaskMailbox, ITaskMailboxTypes} from "../../src/interfaces/core/ITaskMailbox.sol";
 import {IAVSTaskHook} from "../../src/interfaces/avs/l2/IAVSTaskHook.sol";
@@ -23,10 +24,13 @@ contract SetupAVSTaskMailboxConfig is Script {
         vm.startBroadcast(avsPrivateKey);
         console.log("AVS address:", avs);
 
+        // First set the certificate verifier for BN254 curve type (assuming the owner does this)
+        // In production, this would be done by the TaskMailbox owner
+
         // Set the Executor Operator Set Task Config
         ITaskMailboxTypes.ExecutorOperatorSetTaskConfig memory executorOperatorSetTaskConfig = ITaskMailboxTypes
             .ExecutorOperatorSetTaskConfig({
-            certificateVerifier: CERTIFICATE_VERIFIER,
+            curveType: IKeyRegistrarTypes.CurveType.BN254,
             taskHook: IAVSTaskHook(taskHook),
             feeToken: IERC20(address(0)),
             feeCollector: address(0),
@@ -38,8 +42,8 @@ contract SetupAVSTaskMailboxConfig is Script {
         ITaskMailboxTypes.ExecutorOperatorSetTaskConfig memory executorOperatorSetTaskConfigStored =
             ITaskMailbox(taskMailbox).getExecutorOperatorSetTaskConfig(OperatorSet(avs, 1));
         console.log(
-            "Executor Operator Set Task Config set:",
-            executorOperatorSetTaskConfigStored.certificateVerifier,
+            "Executor Operator Set Task Config set with curve type:",
+            uint8(executorOperatorSetTaskConfigStored.curveType),
             address(executorOperatorSetTaskConfigStored.taskHook)
         );
 

--- a/contracts/script/local/SetupAVSTaskMailboxConfig.s.sol
+++ b/contracts/script/local/SetupAVSTaskMailboxConfig.s.sol
@@ -11,9 +11,6 @@ import {ITaskMailbox, ITaskMailboxTypes} from "../../src/interfaces/core/ITaskMa
 import {IAVSTaskHook} from "../../src/interfaces/avs/l2/IAVSTaskHook.sol";
 
 contract SetupAVSTaskMailboxConfig is Script {
-    // Eigenlayer Core Contracts
-    address public CERTIFICATE_VERIFIER = 0xf462d03A82C1F3496B0DFe27E978318eD1720E1f;
-
     function setUp() public {}
 
     function run(address taskMailbox, address taskHook) public {
@@ -23,9 +20,6 @@ contract SetupAVSTaskMailboxConfig is Script {
 
         vm.startBroadcast(avsPrivateKey);
         console.log("AVS address:", avs);
-
-        // First set the certificate verifier for BN254 curve type (assuming the owner does this)
-        // In production, this would be done by the TaskMailbox owner
 
         // Set the Executor Operator Set Task Config
         ITaskMailboxTypes.ExecutorOperatorSetTaskConfig memory executorOperatorSetTaskConfig = ITaskMailboxTypes

--- a/contracts/src/core/TaskMailbox.sol
+++ b/contracts/src/core/TaskMailbox.sol
@@ -256,6 +256,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
      */
     function _setCertificateVerifier(IKeyRegistrarTypes.CurveType curveType, address certificateVerifier) internal {
         require(certificateVerifier != address(0), InvalidAddressZero());
+        require(curveType != IKeyRegistrarTypes.CurveType.NONE, InvalidCurveType());
         certificateVerifiers[curveType] = certificateVerifier;
         emit CertificateVerifierSet(curveType, certificateVerifier);
     }

--- a/contracts/src/core/TaskMailboxStorage.sol
+++ b/contracts/src/core/TaskMailboxStorage.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {ITaskMailbox} from "../interfaces/core/ITaskMailbox.sol";
+import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 
 /**
  * @title TaskMailboxStorage
@@ -20,4 +21,7 @@ abstract contract TaskMailboxStorage is ITaskMailbox {
 
     /// @notice Mapping from executor operator set key to its task configuration
     mapping(bytes32 operatorSetKey => ExecutorOperatorSetTaskConfig config) public executorOperatorSetTaskConfigs;
+
+    /// @notice Mapping from curve type to certificate verifier address
+    mapping(IKeyRegistrarTypes.CurveType curveType => address verifier) public certificateVerifiers;
 }

--- a/contracts/src/interfaces/avs/l2/IAVSTaskHook.sol
+++ b/contracts/src/interfaces/avs/l2/IAVSTaskHook.sol
@@ -42,8 +42,5 @@ interface IAVSTaskHook {
      * @param cert Certificate proving the validity of the result
      * @dev This function can be used to perform additional validation or update AVS-specific state
      */
-    function handleTaskResultSubmission(
-        bytes32 taskHash,
-        IBN254CertificateVerifierTypes.BN254Certificate memory cert
-    ) external;
+    function handleTaskResultSubmission(bytes32 taskHash, bytes memory cert) external;
 }

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -288,11 +288,7 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
      * @param cert Certificate proving the validity of the result
      * @param result Task execution result data
      */
-    function submitResult(
-        bytes32 taskHash,
-        IBN254CertificateVerifierTypes.BN254Certificate memory cert,
-        bytes memory result
-    ) external;
+    function submitResult(bytes32 taskHash, bytes memory cert, bytes memory result) external;
 
     /**
      *

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -137,6 +137,9 @@ interface ITaskMailboxErrors is ITaskMailboxTypes {
 
     /// @notice Thrown when a timestamp is at creation
     error TimestampAtCreation();
+
+    /// @notice Thrown when an operator set owner is invalid
+    error InvalidOperatorSetOwner();
 }
 
 /**
@@ -246,13 +249,6 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
     function setCertificateVerifier(IKeyRegistrarTypes.CurveType curveType, address certificateVerifier) external;
 
     /**
-     * @notice Registers an executor operator set with the TaskMailbox
-     * @param operatorSet The operator set to register
-     * @param isRegistered Whether the operator set is registered
-     */
-    function registerExecutorOperatorSet(OperatorSet memory operatorSet, bool isRegistered) external;
-
-    /**
      * @notice Sets the task configuration for an executor operator set
      * @param operatorSet The operator set to configure
      * @param config Task configuration for the operator set
@@ -261,6 +257,13 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
         OperatorSet memory operatorSet,
         ExecutorOperatorSetTaskConfig memory config
     ) external;
+
+    /**
+     * @notice Registers an executor operator set with the TaskMailbox
+     * @param operatorSet The operator set to register
+     * @param isRegistered Whether the operator set is registered
+     */
+    function registerExecutorOperatorSet(OperatorSet memory operatorSet, bool isRegistered) external;
 
     /**
      * @notice Creates a new task

--- a/contracts/test/TaskMailbox.t.sol
+++ b/contracts/test/TaskMailbox.t.sol
@@ -138,6 +138,18 @@ contract TaskMailboxUnitTests_Constructor is TaskMailboxUnitTests {
         vm.expectRevert(InvalidAddressZero.selector);
         new TaskMailbox(address(this), configs);
     }
+
+    function test_Revert_Constructor_InvalidCurveType() public {
+        ITaskMailboxTypes.CertificateVerifierConfig[] memory configs =
+            new ITaskMailboxTypes.CertificateVerifierConfig[](1);
+        configs[0] = ITaskMailboxTypes.CertificateVerifierConfig({
+            curveType: IKeyRegistrarTypes.CurveType.NONE,
+            verifier: address(0x1234)
+        });
+
+        vm.expectRevert(InvalidCurveType.selector);
+        new TaskMailbox(address(this), configs);
+    }
 }
 
 contract TaskMailboxUnitTests_setCertificateVerifier is TaskMailboxUnitTests {
@@ -161,6 +173,11 @@ contract TaskMailboxUnitTests_setCertificateVerifier is TaskMailboxUnitTests {
     function test_Revert_setCertificateVerifier_ZeroAddress() public {
         vm.expectRevert(InvalidAddressZero.selector);
         taskMailbox.setCertificateVerifier(IKeyRegistrarTypes.CurveType.ECDSA, address(0));
+    }
+
+    function test_Revert_setCertificateVerifier_InvalidCurveType() public {
+        vm.expectRevert(InvalidCurveType.selector);
+        taskMailbox.setCertificateVerifier(IKeyRegistrarTypes.CurveType.NONE, address(0x9999));
     }
 }
 

--- a/contracts/test/mocks/MockAVSTaskHook.sol
+++ b/contracts/test/mocks/MockAVSTaskHook.sol
@@ -22,10 +22,7 @@ contract MockAVSTaskHook is IAVSTaskHook {
         //TODO: Implement
     }
 
-    function handleTaskResultSubmission(
-        bytes32, /*taskHash*/
-        IBN254CertificateVerifierTypes.BN254Certificate memory /*cert*/
-    ) external {
+    function handleTaskResultSubmission(bytes32, /*taskHash*/ bytes memory /*cert*/ ) external {
         //TODO: Implement
     }
 }

--- a/contracts/test/mocks/MockBN254CertificateVerifier.sol
+++ b/contracts/test/mocks/MockBN254CertificateVerifier.sol
@@ -10,6 +10,13 @@ import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/Operato
 import {BN254} from "@eigenlayer-contracts/src/contracts/libraries/BN254.sol";
 
 contract MockBN254CertificateVerifier is IBN254CertificateVerifier {
+    // Mapping to store operator set owners for testing
+    mapping(bytes32 => address) public operatorSetOwners;
+
+    function setOperatorSetOwner(OperatorSet memory operatorSet, address owner) external {
+        operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))] = owner;
+    }
+
     function updateOperatorTable(
         OperatorSet calldata, /*operatorSet*/
         uint32, /*referenceTimestamp*/
@@ -54,9 +61,11 @@ contract MockBN254CertificateVerifier is IBN254CertificateVerifier {
     }
 
     function getOperatorSetOwner(
-        OperatorSet memory /*operatorSet*/
-    ) external pure returns (address) {
-        return address(0);
+        OperatorSet memory operatorSet
+    ) external view returns (address) {
+        // Return the configured owner, or the AVS address by default
+        address owner = operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))];
+        return owner != address(0) ? owner : operatorSet.avs;
     }
 
     function latestReferenceTimestamp(

--- a/contracts/test/mocks/MockBN254CertificateVerifier.sol
+++ b/contracts/test/mocks/MockBN254CertificateVerifier.sol
@@ -5,13 +5,15 @@ import {
     IBN254CertificateVerifier,
     IBN254CertificateVerifierTypes
 } from "@eigenlayer-contracts/src/contracts/interfaces/IBN254CertificateVerifier.sol";
+import {IBN254TableCalculatorTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IBN254TableCalculator.sol";
 import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {BN254} from "@eigenlayer-contracts/src/contracts/libraries/BN254.sol";
 
 contract MockBN254CertificateVerifier is IBN254CertificateVerifier {
     function updateOperatorTable(
         OperatorSet calldata, /*operatorSet*/
         uint32, /*referenceTimestamp*/
-        BN254OperatorSetInfo memory, /*operatorSetInfo*/
+        IBN254TableCalculatorTypes.BN254OperatorSetInfo memory, /*operatorSetInfo*/
         OperatorSetConfig calldata /*operatorSetConfig*/
     ) external pure {}
 
@@ -67,5 +69,44 @@ contract MockBN254CertificateVerifier is IBN254CertificateVerifier {
         OperatorSet memory /*operatorSet*/
     ) external pure returns (uint32) {
         return 86_400;
+    }
+
+    function trySignatureVerification(
+        bytes32, /*msgHash*/
+        BN254.G1Point memory, /*aggPubkey*/
+        BN254.G2Point memory, /*apkG2*/
+        BN254.G1Point memory /*signature*/
+    ) external pure returns (bool pairingSuccessful, bool signatureValid) {
+        return (true, true);
+    }
+
+    function getNonsignerOperatorInfo(
+        OperatorSet memory, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        uint256 /*operatorIndex*/
+    ) external pure returns (IBN254TableCalculatorTypes.BN254OperatorInfo memory) {
+        uint256[] memory weights = new uint256[](0);
+        return IBN254TableCalculatorTypes.BN254OperatorInfo({pubkey: BN254.G1Point(0, 0), weights: weights});
+    }
+
+    function isNonsignerCached(
+        OperatorSet memory, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        uint256 /*operatorIndex*/
+    ) external pure returns (bool) {
+        return false;
+    }
+
+    function getOperatorSetInfo(
+        OperatorSet memory, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (IBN254TableCalculatorTypes.BN254OperatorSetInfo memory) {
+        uint256[] memory totalWeights = new uint256[](0);
+        return IBN254TableCalculatorTypes.BN254OperatorSetInfo({
+            operatorInfoTreeRoot: bytes32(0),
+            numOperators: 0,
+            aggregatePubkey: BN254.G1Point(0, 0),
+            totalWeights: totalWeights
+        });
     }
 }

--- a/contracts/test/mocks/MockBN254CertificateVerifierFailure.sol
+++ b/contracts/test/mocks/MockBN254CertificateVerifierFailure.sol
@@ -1,8 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IBN254CertificateVerifier} from "@eigenlayer-contracts/src/contracts/interfaces/IBN254CertificateVerifier.sol";
+import {
+    IBN254CertificateVerifier,
+    IBN254CertificateVerifierTypes
+} from "@eigenlayer-contracts/src/contracts/interfaces/IBN254CertificateVerifier.sol";
+import {IBN254TableCalculatorTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IBN254TableCalculator.sol";
 import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {BN254} from "@eigenlayer-contracts/src/contracts/libraries/BN254.sol";
 
 /**
  * @title MockBN254CertificateVerifierFailure
@@ -13,7 +18,7 @@ contract MockBN254CertificateVerifierFailure is IBN254CertificateVerifier {
     function updateOperatorTable(
         OperatorSet calldata, /*operatorSet*/
         uint32, /*referenceTimestamp*/
-        BN254OperatorSetInfo memory, /*operatorSetInfo*/
+        IBN254TableCalculatorTypes.BN254OperatorSetInfo memory, /*operatorSetInfo*/
         OperatorSetConfig calldata /*operatorSetConfig*/
     ) external pure {}
 
@@ -69,5 +74,44 @@ contract MockBN254CertificateVerifierFailure is IBN254CertificateVerifier {
         OperatorSet memory /*operatorSet*/
     ) external pure returns (uint32) {
         return 86_400;
+    }
+
+    function trySignatureVerification(
+        bytes32, /*msgHash*/
+        BN254.G1Point memory, /*aggPubkey*/
+        BN254.G2Point memory, /*apkG2*/
+        BN254.G1Point memory /*signature*/
+    ) external pure returns (bool pairingSuccessful, bool signatureValid) {
+        return (true, false); // Pairing succeeds but signature is invalid
+    }
+
+    function getNonsignerOperatorInfo(
+        OperatorSet memory, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        uint256 /*operatorIndex*/
+    ) external pure returns (IBN254TableCalculatorTypes.BN254OperatorInfo memory) {
+        uint256[] memory weights = new uint256[](0);
+        return IBN254TableCalculatorTypes.BN254OperatorInfo({pubkey: BN254.G1Point(0, 0), weights: weights});
+    }
+
+    function isNonsignerCached(
+        OperatorSet memory, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        uint256 /*operatorIndex*/
+    ) external pure returns (bool) {
+        return false;
+    }
+
+    function getOperatorSetInfo(
+        OperatorSet memory, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (IBN254TableCalculatorTypes.BN254OperatorSetInfo memory) {
+        uint256[] memory totalWeights = new uint256[](0);
+        return IBN254TableCalculatorTypes.BN254OperatorSetInfo({
+            operatorInfoTreeRoot: bytes32(0),
+            numOperators: 0,
+            aggregatePubkey: BN254.G1Point(0, 0),
+            totalWeights: totalWeights
+        });
     }
 }

--- a/contracts/test/mocks/MockBN254CertificateVerifierFailure.sol
+++ b/contracts/test/mocks/MockBN254CertificateVerifierFailure.sol
@@ -15,6 +15,13 @@ import {BN254} from "@eigenlayer-contracts/src/contracts/libraries/BN254.sol";
  * @dev Used for testing certificate verification failure scenarios
  */
 contract MockBN254CertificateVerifierFailure is IBN254CertificateVerifier {
+    // Mapping to store operator set owners for testing
+    mapping(bytes32 => address) public operatorSetOwners;
+
+    function setOperatorSetOwner(OperatorSet memory operatorSet, address owner) external {
+        operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))] = owner;
+    }
+
     function updateOperatorTable(
         OperatorSet calldata, /*operatorSet*/
         uint32, /*referenceTimestamp*/
@@ -59,9 +66,11 @@ contract MockBN254CertificateVerifierFailure is IBN254CertificateVerifier {
     }
 
     function getOperatorSetOwner(
-        OperatorSet memory /*operatorSet*/
-    ) external pure returns (address) {
-        return address(0);
+        OperatorSet memory operatorSet
+    ) external view returns (address) {
+        // Return the configured owner, or the AVS address by default
+        address owner = operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))];
+        return owner != address(0) ? owner : operatorSet.avs;
     }
 
     function latestReferenceTimestamp(

--- a/contracts/test/mocks/MockECDSACertificateVerifier.sol
+++ b/contracts/test/mocks/MockECDSACertificateVerifier.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {
+    IECDSACertificateVerifier,
+    IECDSACertificateVerifierTypes
+} from "@eigenlayer-contracts/src/contracts/interfaces/IECDSACertificateVerifier.sol";
+import {IECDSATableCalculatorTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IECDSATableCalculator.sol";
+import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+
+contract MockECDSACertificateVerifier is IECDSACertificateVerifier {
+    // Mapping to store operator set owners for testing
+    mapping(bytes32 => address) public operatorSetOwners;
+
+    function setOperatorSetOwner(OperatorSet memory operatorSet, address owner) external {
+        operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))] = owner;
+    }
+
+    function updateOperatorTable(
+        OperatorSet calldata, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        ECDSAOperatorInfo[] calldata, /*operatorInfos*/
+        OperatorSetConfig calldata /*operatorSetConfig*/
+    ) external pure {}
+
+    function verifyCertificate(
+        OperatorSet calldata, /*operatorSet*/
+        ECDSACertificate memory /*cert*/
+    ) external pure returns (uint256[] memory signedStakes) {
+        return new uint256[](0);
+    }
+
+    function verifyCertificateProportion(
+        OperatorSet calldata, /*operatorSet*/
+        ECDSACertificate memory, /*cert*/
+        uint16[] memory /*totalStakeProportionThresholds*/
+    ) external pure returns (bool) {
+        return true;
+    }
+
+    function verifyCertificateNominal(
+        OperatorSet calldata, /*operatorSet*/
+        ECDSACertificate memory, /*cert*/
+        uint256[] memory /*totalStakeNominalThresholds*/
+    ) external pure returns (bool) {
+        return true;
+    }
+
+    // Implement IBaseCertificateVerifier required functions
+    function operatorTableUpdater(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (address) {
+        return address(0);
+    }
+
+    function getLatestReferenceTimestamp(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (uint32) {
+        return 0;
+    }
+
+    function getOperatorSetOwner(
+        OperatorSet memory operatorSet
+    ) external view returns (address) {
+        // Return the configured owner, or the AVS address by default
+        address owner = operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))];
+        return owner != address(0) ? owner : operatorSet.avs;
+    }
+
+    function latestReferenceTimestamp(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (uint32) {
+        return 0;
+    }
+
+    function maxOperatorTableStaleness(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (uint32) {
+        return 86_400;
+    }
+
+    function getCachedSignerList(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (address[] memory) {
+        return new address[](0);
+    }
+
+    function getOperatorInfos(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (ECDSAOperatorInfo[] memory) {
+        return new ECDSAOperatorInfo[](0);
+    }
+
+    function getOperatorInfo(
+        OperatorSet calldata, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        uint32 /*operatorIndex*/
+    ) external pure returns (ECDSAOperatorInfo memory) {
+        uint256[] memory weights = new uint256[](0);
+        return ECDSAOperatorInfo({pubkey: address(0), weights: weights});
+    }
+
+    function getOperatorCount(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (uint32) {
+        return 0;
+    }
+
+    function getTotalStakes(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (uint256[] memory) {
+        return new uint256[](0);
+    }
+
+    function domainSeparator() external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function calculateCertificateDigest(
+        uint32, /*referenceTimestamp*/
+        bytes32 /*messageHash*/
+    ) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+}

--- a/contracts/test/mocks/MockECDSACertificateVerifierFailure.sol
+++ b/contracts/test/mocks/MockECDSACertificateVerifierFailure.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {
+    IECDSACertificateVerifier,
+    IECDSACertificateVerifierTypes
+} from "@eigenlayer-contracts/src/contracts/interfaces/IECDSACertificateVerifier.sol";
+import {IECDSATableCalculatorTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IECDSATableCalculator.sol";
+import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+
+contract MockECDSACertificateVerifierFailure is IECDSACertificateVerifier {
+    // Mapping to store operator set owners for testing
+    mapping(bytes32 => address) public operatorSetOwners;
+
+    function setOperatorSetOwner(OperatorSet memory operatorSet, address owner) external {
+        operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))] = owner;
+    }
+
+    function updateOperatorTable(
+        OperatorSet calldata, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        ECDSAOperatorInfo[] calldata, /*operatorInfos*/
+        OperatorSetConfig calldata /*operatorSetConfig*/
+    ) external pure {}
+
+    function verifyCertificate(
+        OperatorSet calldata, /*operatorSet*/
+        ECDSACertificate memory /*cert*/
+    ) external pure returns (uint256[] memory signedStakes) {
+        return new uint256[](0);
+    }
+
+    function verifyCertificateProportion(
+        OperatorSet calldata, /*operatorSet*/
+        ECDSACertificate memory, /*cert*/
+        uint16[] memory /*totalStakeProportionThresholds*/
+    ) external pure returns (bool) {
+        return false; // Always fail
+    }
+
+    function verifyCertificateNominal(
+        OperatorSet calldata, /*operatorSet*/
+        ECDSACertificate memory, /*cert*/
+        uint256[] memory /*totalStakeNominalThresholds*/
+    ) external pure returns (bool) {
+        return false; // Always fail
+    }
+
+    // Implement IBaseCertificateVerifier required functions
+    function operatorTableUpdater(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (address) {
+        return address(0);
+    }
+
+    function getLatestReferenceTimestamp(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (uint32) {
+        return 0;
+    }
+
+    function getOperatorSetOwner(
+        OperatorSet memory operatorSet
+    ) external view returns (address) {
+        // Return the configured owner, or the AVS address by default
+        address owner = operatorSetOwners[keccak256(abi.encode(operatorSet.avs, operatorSet.id))];
+        return owner != address(0) ? owner : operatorSet.avs;
+    }
+
+    function latestReferenceTimestamp(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (uint32) {
+        return 0;
+    }
+
+    function maxOperatorTableStaleness(
+        OperatorSet memory /*operatorSet*/
+    ) external pure returns (uint32) {
+        return 86_400;
+    }
+
+    function getCachedSignerList(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (address[] memory) {
+        return new address[](0);
+    }
+
+    function getOperatorInfos(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (ECDSAOperatorInfo[] memory) {
+        return new ECDSAOperatorInfo[](0);
+    }
+
+    function getOperatorInfo(
+        OperatorSet calldata, /*operatorSet*/
+        uint32, /*referenceTimestamp*/
+        uint32 /*operatorIndex*/
+    ) external pure returns (ECDSAOperatorInfo memory) {
+        uint256[] memory weights = new uint256[](0);
+        return ECDSAOperatorInfo({pubkey: address(0), weights: weights});
+    }
+
+    function getOperatorCount(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (uint32) {
+        return 0;
+    }
+
+    function getTotalStakes(
+        OperatorSet calldata, /*operatorSet*/
+        uint32 /*referenceTimestamp*/
+    ) external pure returns (uint256[] memory) {
+        return new uint256[](0);
+    }
+
+    function domainSeparator() external pure returns (bytes32) {
+        return bytes32(0);
+    }
+
+    function calculateCertificateDigest(
+        uint32, /*referenceTimestamp*/
+        bytes32 /*messageHash*/
+    ) external pure returns (bytes32) {
+        return bytes32(0);
+    }
+}

--- a/contracts/test/mocks/ReentrantAttacker.sol
+++ b/contracts/test/mocks/ReentrantAttacker.sol
@@ -83,15 +83,12 @@ contract ReentrantAttacker is IAVSTaskHook, ITaskMailboxTypes {
                     nonSignerWitnesses: new IBN254CertificateVerifierTypes.BN254OperatorInfoWitness[](0)
                 });
                 // Try to reenter submitResult
-                taskMailbox.submitResult(attackTaskHash, cert, result);
+                taskMailbox.submitResult(attackTaskHash, abi.encode(cert), result);
             }
         }
     }
 
-    function handleTaskResultSubmission(
-        bytes32,
-        IBN254CertificateVerifierTypes.BN254Certificate memory
-    ) external override {
+    function handleTaskResultSubmission(bytes32, bytes memory) external {
         if (!attackOnPost) {
             if (attackCreateTask) {
                 // Reconstruct TaskParams for the attack
@@ -114,7 +111,7 @@ contract ReentrantAttacker is IAVSTaskHook, ITaskMailboxTypes {
                     nonSignerWitnesses: new IBN254CertificateVerifierTypes.BN254OperatorInfoWitness[](0)
                 });
                 // Try to reenter submitResult
-                taskMailbox.submitResult(attackTaskHash, cert, result);
+                taskMailbox.submitResult(attackTaskHash, abi.encode(cert), result);
             }
         }
     }


### PR DESCRIPTION
**Motivation:**

Updating the `TaskMailbox` to support multiple certificate verifiers including `ECDSA`.

**Modifications:**

* Relevant updates to `ITaskMailbox`, `TaskMailbox` and `TaskMailboxStorage`.
* Updated the `eigenlayer-middleware` dependency to pull in the latest ECDSA changes
* Updated `foundry.toml` to suppress `test` and `lib` warnings.

**Result:**

ECDSA support in the `TaskMailbox`.