### PR TITLE
chore: taskMailbox cleanup

### DIFF
--- a/contracts/script/local/DeployTaskMailbox.s.sol
+++ b/contracts/script/local/DeployTaskMailbox.s.sol
@@ -19,18 +19,7 @@ contract DeployTaskMailbox is Script {
         vm.startBroadcast(deployerPrivateKey);
         console.log("Deployer address:", deployer);
 
-        ITaskMailboxTypes.CertificateVerifierConfig[] memory certificateVerifiers =
-            new ITaskMailboxTypes.CertificateVerifierConfig[](2);
-        certificateVerifiers[0] = ITaskMailboxTypes.CertificateVerifierConfig({
-            curveType: IKeyRegistrarTypes.CurveType.BN254,
-            verifier: bn254CertVerifier
-        });
-        certificateVerifiers[1] = ITaskMailboxTypes.CertificateVerifierConfig({
-            curveType: IKeyRegistrarTypes.CurveType.ECDSA,
-            verifier: ecdsaCertVerifier
-        });
-
-        TaskMailbox taskMailbox = new TaskMailbox(deployer, certificateVerifiers);
+        TaskMailbox taskMailbox = new TaskMailbox(deployer, bn254CertVerifier, ecdsaCertVerifier);
         console.log("TaskMailbox deployed to:", address(taskMailbox));
 
         vm.stopBroadcast();

--- a/contracts/src/core/TaskMailbox.sol
+++ b/contracts/src/core/TaskMailbox.sol
@@ -62,9 +62,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
             InvalidOperatorSetOwner()
         );
 
-        // TODO: Do we need to make taskHook ERC165 compliant? and check for ERC165 interface support?
         // TODO: Double check if any other config checks are needed.
-
         require(config.curveType != IKeyRegistrarTypes.CurveType.NONE, InvalidCurveType());
         require(config.taskHook != IAVSTaskHook(address(0)), InvalidAddressZero());
         require(config.taskSLA > 0, TaskSLAIsZero());
@@ -113,8 +111,10 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
             ExecutorOperatorSetTaskConfigNotSet()
         );
 
-        // Pre-task submission checks: AVS can validate the caller, operator set and task payload
-        taskConfig.taskHook.validatePreTaskCreation(msg.sender, taskParams.executorOperatorSet, taskParams.payload);
+        // Pre-task submission checks:
+        // 1. AVS can validate the caller and task params.
+        // 2. AVS can design fee markets to validate their avsFee against.
+        taskConfig.taskHook.validatePreTaskCreation(msg.sender, taskParams);
 
         bytes32 taskHash = keccak256(abi.encode(_globalTaskCount, address(this), block.chainid, taskParams));
         _globalTaskCount = _globalTaskCount + 1;
@@ -130,6 +130,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
             0, // TODO: Update with fee split % variable
             taskConfig,
             taskParams.payload,
+            bytes(""),
             bytes("")
         );
 
@@ -139,9 +140,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
             taskConfig.feeToken.safeTransferFrom(msg.sender, address(this), taskParams.avsFee);
         }
 
-        // Post-task submission checks:
-        // 1. AVS can write to storage in their hook for validating task lifecycle
-        // 2. AVS can design fee markets to validate their avsFee against.
+        // Post-task submission checks: AVS can write to storage in their hook for validating task lifecycle
         taskConfig.taskHook.handlePostTaskCreation(taskHash);
 
         emit TaskCreated(
@@ -166,10 +165,13 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
         require(status == TaskStatus.CREATED, InvalidTaskStatus(TaskStatus.CREATED, status));
         require(block.timestamp > task.creationTime, TimestampAtCreation());
 
+        // Pre-task result submission checks: AVS can validate the caller, task result, params and certificate.
+        task.executorOperatorSetTaskConfig.taskHook.validatePreTaskResultSubmission(msg.sender, taskHash, cert, result);
+
         uint16[] memory totalStakeProportionThresholds = new uint16[](1);
         totalStakeProportionThresholds[0] = task.executorOperatorSetTaskConfig.stakeProportionThreshold;
-        OperatorSet memory executorOperatorSet = OperatorSet(task.avs, task.executorOperatorSetId);
 
+        OperatorSet memory executorOperatorSet = OperatorSet(task.avs, task.executorOperatorSetId);
         bool isCertificateValid;
         if (task.executorOperatorSetTaskConfig.curveType == IKeyRegistrarTypes.CurveType.BN254) {
             // BN254 Certificate verification
@@ -191,14 +193,13 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
         require(isCertificateValid, CertificateVerificationFailed());
 
         task.status = TaskStatus.VERIFIED;
+        task.executorCert = cert;
         task.result = result;
 
-        // Task result submission checks:
-        // 1. AVS can validate the task result, params and certificate.
-        // 2. It can update hook storage for task lifecycle if needed.
-        task.executorOperatorSetTaskConfig.taskHook.handleTaskResultSubmission(taskHash, cert);
+        // Task result submission checks: AVS can update hook storage for task lifecycle if needed.
+        task.executorOperatorSetTaskConfig.taskHook.handlePostTaskResultSubmission(taskHash);
 
-        emit TaskVerified(msg.sender, taskHash, task.avs, task.executorOperatorSetId, task.result);
+        emit TaskVerified(msg.sender, taskHash, task.avs, task.executorOperatorSetId, task.executorCert, task.result);
     }
 
     /**
@@ -280,6 +281,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
             task.feeSplit,
             task.executorOperatorSetTaskConfig,
             task.payload,
+            task.executorCert,
             task.result
         );
     }

--- a/contracts/src/core/TaskMailbox.sol
+++ b/contracts/src/core/TaskMailbox.sol
@@ -116,10 +116,10 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
         // Pre-task submission checks: AVS can validate the caller, operator set and task payload
         taskConfig.taskHook.validatePreTaskCreation(msg.sender, taskParams.executorOperatorSet, taskParams.payload);
 
-        bytes32 taskHash = keccak256(abi.encode(globalTaskCount, address(this), block.chainid, taskParams));
-        globalTaskCount = globalTaskCount + 1;
+        bytes32 taskHash = keccak256(abi.encode(_globalTaskCount, address(this), block.chainid, taskParams));
+        _globalTaskCount = _globalTaskCount + 1;
 
-        tasks[taskHash] = Task(
+        _tasks[taskHash] = Task(
             msg.sender,
             block.timestamp.toUint96(),
             TaskStatus.CREATED,
@@ -161,7 +161,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
     function submitResult(bytes32 taskHash, bytes memory cert, bytes memory result) external nonReentrant {
         // TODO: Handle case of anyone submitting a result with empty signature in the certificate.
 
-        Task storage task = tasks[taskHash];
+        Task storage task = _tasks[taskHash];
         TaskStatus status = _getTaskStatus(task);
         require(status == TaskStatus.CREATED, InvalidTaskStatus(TaskStatus.CREATED, status));
         require(block.timestamp > task.creationTime, TimestampAtCreation());
@@ -268,7 +268,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
     function getTaskInfo(
         bytes32 taskHash
     ) external view returns (Task memory) {
-        Task memory task = tasks[taskHash];
+        Task memory task = _tasks[taskHash];
         return Task(
             task.creator,
             task.creationTime,
@@ -288,7 +288,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
     function getTaskStatus(
         bytes32 taskHash
     ) external view returns (TaskStatus) {
-        Task memory task = tasks[taskHash];
+        Task memory task = _tasks[taskHash];
         return _getTaskStatus(task);
     }
 
@@ -296,7 +296,7 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
     function getTaskResult(
         bytes32 taskHash
     ) external view returns (bytes memory) {
-        Task memory task = tasks[taskHash];
+        Task memory task = _tasks[taskHash];
         TaskStatus status = _getTaskStatus(task);
         require(status == TaskStatus.VERIFIED, InvalidTaskStatus(TaskStatus.VERIFIED, status));
         return task.result;

--- a/contracts/src/core/TaskMailbox.sol
+++ b/contracts/src/core/TaskMailbox.sol
@@ -166,6 +166,8 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
 
     /// @inheritdoc ITaskMailbox
     function submitResult(bytes32 taskHash, bytes memory cert, bytes memory result) external nonReentrant {
+        // TODO: Handle case of anyone submitting a result with empty signature in the certificate.
+
         Task storage task = tasks[taskHash];
         TaskStatus status = _getTaskStatus(task);
         require(status == TaskStatus.CREATED, InvalidTaskStatus(TaskStatus.CREATED, status));

--- a/contracts/src/core/TaskMailbox.sol
+++ b/contracts/src/core/TaskMailbox.sol
@@ -167,22 +167,6 @@ contract TaskMailbox is Ownable, ReentrancyGuard, TaskMailboxStorage {
     }
 
     /// @inheritdoc ITaskMailbox
-    function cancelTask(
-        bytes32 taskHash
-    ) external {
-        // TODO: Check if we even need this cancelTask function - Maybe have a flag with isCancelable in the AVS Task Config and further gate at the protocol level.
-        Task storage task = tasks[taskHash];
-        TaskStatus status = _getTaskStatus(task);
-        require(status == TaskStatus.Created, InvalidTaskStatus(TaskStatus.Created, status));
-        require(msg.sender == task.creator, InvalidTaskCreator());
-        require(block.timestamp > task.creationTime, TimestampAtCreation());
-
-        task.status = TaskStatus.Canceled;
-
-        emit TaskCanceled(msg.sender, taskHash, task.avs, task.executorOperatorSetId);
-    }
-
-    /// @inheritdoc ITaskMailbox
     function submitResult(bytes32 taskHash, bytes memory cert, bytes memory result) external nonReentrant {
         Task storage task = tasks[taskHash];
         TaskStatus status = _getTaskStatus(task);

--- a/contracts/src/core/TaskMailboxStorage.sol
+++ b/contracts/src/core/TaskMailboxStorage.sol
@@ -17,10 +17,10 @@ abstract contract TaskMailboxStorage is ITaskMailbox {
     address public immutable ECDSA_CERTIFICATE_VERIFIER;
 
     /// @notice Global counter for tasks created across the TaskMailbox
-    uint256 internal globalTaskCount;
+    uint256 internal _globalTaskCount;
 
     /// @notice Mapping from task hash to task details
-    mapping(bytes32 taskHash => Task task) internal tasks;
+    mapping(bytes32 taskHash => Task task) internal _tasks;
 
     /// @notice Mapping to track registered executor operator sets by their keys
     mapping(bytes32 operatorSetKey => bool isRegistered) public isExecutorOperatorSetRegistered;

--- a/contracts/src/core/TaskMailboxStorage.sol
+++ b/contracts/src/core/TaskMailboxStorage.sol
@@ -10,6 +10,12 @@ import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces
  * @notice Storage contract for the TaskMailbox contract.
  */
 abstract contract TaskMailboxStorage is ITaskMailbox {
+    /// @notice Immutable BN254 certificate verifier
+    address public immutable BN254_CERTIFICATE_VERIFIER;
+
+    /// @notice Immutable ECDSA certificate verifier
+    address public immutable ECDSA_CERTIFICATE_VERIFIER;
+
     /// @notice Global counter for tasks created across the TaskMailbox
     uint256 internal globalTaskCount;
 
@@ -22,6 +28,13 @@ abstract contract TaskMailboxStorage is ITaskMailbox {
     /// @notice Mapping from executor operator set key to its task configuration
     mapping(bytes32 operatorSetKey => ExecutorOperatorSetTaskConfig config) public executorOperatorSetTaskConfigs;
 
-    /// @notice Mapping from curve type to certificate verifier address
-    mapping(IKeyRegistrarTypes.CurveType curveType => address verifier) public certificateVerifiers;
+    /**
+     * @notice Constructor for TaskMailboxStorage
+     * @param _bn254CertificateVerifier Address of the BN254 certificate verifier
+     * @param _ecdsaCertificateVerifier Address of the ECDSA certificate verifier
+     */
+    constructor(address _bn254CertificateVerifier, address _ecdsaCertificateVerifier) {
+        BN254_CERTIFICATE_VERIFIER = _bn254CertificateVerifier;
+        ECDSA_CERTIFICATE_VERIFIER = _ecdsaCertificateVerifier;
+    }
 }

--- a/contracts/src/interfaces/avs/l2/IAVSTaskHook.sol
+++ b/contracts/src/interfaces/avs/l2/IAVSTaskHook.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IBN254CertificateVerifierTypes} from
-    "@eigenlayer-contracts/src/contracts/interfaces/IBN254CertificateVerifier.sol";
+import {ITaskMailboxTypes} from "../../core/ITaskMailbox.sol";
 import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 
 /**
@@ -17,15 +16,10 @@ interface IAVSTaskHook {
     /**
      * @notice Validates a task before it is created
      * @param caller Address that is creating the task
-     * @param operatorSet The operator set that will execute the task
-     * @param payload Task payload
+     * @param taskParams Task parameters
      * @dev This function should revert if the task should not be created
      */
-    function validatePreTaskCreation(
-        address caller,
-        OperatorSet memory operatorSet,
-        bytes memory payload
-    ) external view;
+    function validatePreTaskCreation(address caller, ITaskMailboxTypes.TaskParams memory taskParams) external view;
 
     /**
      * @notice Handles a task after it is created
@@ -37,10 +31,34 @@ interface IAVSTaskHook {
     ) external;
 
     /**
-     * @notice Handles a task result submission
+     * @notice Validates a task before it is submitted for verification
+     * @param caller Address that is submitting the result
      * @param taskHash Unique identifier of the task
      * @param cert Certificate proving the validity of the result
+     * @param result Task execution result data
+     * @dev This function should revert if the task should not be verified
+     */
+    function validatePreTaskResultSubmission(
+        address caller,
+        bytes32 taskHash,
+        bytes memory cert,
+        bytes memory result
+    ) external view;
+
+    /**
+     * @notice Handles a task result submission
+     * @param taskHash Unique identifier of the task
      * @dev This function can be used to perform additional validation or update AVS-specific state
      */
-    function handleTaskResultSubmission(bytes32 taskHash, bytes memory cert) external;
+    function handlePostTaskResultSubmission(
+        bytes32 taskHash
+    ) external;
+
+    /**
+     * @notice Calculates the fee for a task payload against a specific fee market
+     * @param operatorSet The operator set that will execute the task
+     * @param payload Task payload
+     * @return The fee for the task
+     */
+    function calculateTaskFee(OperatorSet memory operatorSet, bytes memory payload) external view returns (uint96);
 }

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -150,13 +150,6 @@ interface ITaskMailboxErrors is ITaskMailboxTypes {
  */
 interface ITaskMailboxEvents is ITaskMailboxTypes {
     /**
-     * @notice Emitted when a certificate verifier is set
-     * @param curveType The curve type for the verifier
-     * @param certificateVerifier Address of the certificate verifier
-     */
-    event CertificateVerifierSet(IKeyRegistrarTypes.CurveType indexed curveType, address indexed certificateVerifier);
-
-    /**
      * @notice Emitted when an executor operator set is registered
      * @param caller Address that called the registration function
      * @param avs Address of the AVS being registered
@@ -233,13 +226,6 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
      */
 
     /**
-     * @notice Sets a certificate verifier for a specific curve type
-     * @param curveType The curve type for the verifier
-     * @param certificateVerifier Address of the certificate verifier
-     */
-    function setCertificateVerifier(IKeyRegistrarTypes.CurveType curveType, address certificateVerifier) external;
-
-    /**
      * @notice Sets the task configuration for an executor operator set
      * @param operatorSet The operator set to configure
      * @param config Task configuration for the operator set
@@ -287,15 +273,6 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
     function isExecutorOperatorSetRegistered(
         bytes32 operatorSetKey
     ) external view returns (bool);
-
-    /**
-     * @notice Gets the certificate verifier for a specific curve type
-     * @param curveType The curve type to get the verifier for
-     * @return Address of the certificate verifier
-     */
-    function getCertificateVerifier(
-        IKeyRegistrarTypes.CurveType curveType
-    ) external view returns (address);
 
     /**
      * @notice Gets the task configuration for an executor operator set

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -68,7 +68,6 @@ interface ITaskMailboxTypes {
     enum TaskStatus {
         // TODO: `Created` status cannot be enum value 0 since that is the default value. Figure out how to handle this.
         Created,
-        Canceled,
         Verified,
         Expired
     }
@@ -204,17 +203,6 @@ interface ITaskMailboxEvents is ITaskMailboxTypes {
     );
 
     /**
-     * @notice Emitted when a task is canceled
-     * @param creator Address that created the task
-     * @param taskHash Unique identifier of the task
-     * @param avs Address of the AVS handling the task
-     * @param executorOperatorSetId ID of the executor operator set
-     */
-    event TaskCanceled(
-        address indexed creator, bytes32 indexed taskHash, address indexed avs, uint32 executorOperatorSetId
-    );
-
-    /**
      * @notice Emitted when a task is verified
      * @param aggregator Address that submitted the verification
      * @param taskHash Unique identifier of the task
@@ -275,14 +263,6 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
     function createTask(
         TaskParams memory taskParams
     ) external returns (bytes32 taskHash);
-
-    /**
-     * @notice Cancels a task that has been created but not yet verified
-     * @param taskHash Unique identifier of the task to cancel
-     */
-    function cancelTask(
-        bytes32 taskHash
-    ) external;
 
     /**
      * @notice Submits the result of a task execution

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -85,6 +85,7 @@ interface ITaskMailboxTypes {
      * @param feeSplit Percentage split of fees taken by the TaskMailbox
      * @param executorOperatorSetTaskConfig Configuration for executor operator set task execution
      * @param payload Task payload
+     * @param executorCert Executor certificate
      * @param result Task execution result data
      */
     struct Task {
@@ -99,6 +100,7 @@ interface ITaskMailboxTypes {
         uint16 feeSplit;
         ExecutorOperatorSetTaskConfig executorOperatorSetTaskConfig;
         bytes payload;
+        bytes executorCert;
         bytes result;
     }
 }
@@ -202,6 +204,7 @@ interface ITaskMailboxEvents is ITaskMailboxTypes {
      * @param taskHash Unique identifier of the task
      * @param avs Address of the AVS handling the task
      * @param executorOperatorSetId ID of the executor operator set
+     * @param executorCert Executor certificate
      * @param result Task execution result data
      */
     event TaskVerified(
@@ -209,6 +212,7 @@ interface ITaskMailboxEvents is ITaskMailboxTypes {
         bytes32 indexed taskHash,
         address indexed avs,
         uint32 executorOperatorSetId,
+        bytes executorCert,
         bytes result
     );
 }

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -66,10 +66,11 @@ interface ITaskMailboxTypes {
      * @notice Status of a task in the system
      */
     enum TaskStatus {
-        // TODO: `Created` status cannot be enum value 0 since that is the default value. Figure out how to handle this.
-        Created,
-        Verified,
-        Expired
+        NONE, // 0 - Default value for uninitialized tasks
+        CREATED, // 1 - Task has been created
+        VERIFIED, // 2 - Task has been verified
+        EXPIRED // 3 - Task has expired
+
     }
 
     /**

--- a/contracts/test/TaskMailbox.t.sol
+++ b/contracts/test/TaskMailbox.t.sol
@@ -565,7 +565,7 @@ contract TaskMailboxUnitTests_submitResult is TaskMailboxUnitTests {
 
         // Expect event
         vm.expectEmit(true, true, true, true, address(taskMailbox));
-        emit TaskVerified(aggregator, taskHash, avs, executorOperatorSetId, fuzzResult);
+        emit TaskVerified(aggregator, taskHash, avs, executorOperatorSetId, abi.encode(cert), fuzzResult);
 
         // Submit result
         vm.prank(aggregator);
@@ -578,6 +578,10 @@ contract TaskMailboxUnitTests_submitResult is TaskMailboxUnitTests {
         // Verify result was stored
         bytes memory storedResult = taskMailbox.getTaskResult(taskHash);
         assertEq(storedResult, fuzzResult);
+
+        // Verify certificate was stored
+        Task memory task = taskMailbox.getTaskInfo(taskHash);
+        assertEq(task.executorCert, abi.encode(cert));
     }
 
     function testFuzz_submitResult_WithECDSACertificate(
@@ -604,7 +608,7 @@ contract TaskMailboxUnitTests_submitResult is TaskMailboxUnitTests {
 
         // Expect event
         vm.expectEmit(true, true, true, true);
-        emit TaskVerified(aggregator, newTaskHash, avs, executorOperatorSetId, fuzzResult);
+        emit TaskVerified(aggregator, newTaskHash, avs, executorOperatorSetId, abi.encode(cert), fuzzResult);
 
         // Submit result with ECDSA certificate
         vm.prank(aggregator);
@@ -617,6 +621,10 @@ contract TaskMailboxUnitTests_submitResult is TaskMailboxUnitTests {
         // Verify result was stored
         bytes memory storedResult = taskMailbox.getTaskResult(newTaskHash);
         assertEq(storedResult, fuzzResult);
+
+        // Verify certificate was stored
+        Task memory task = taskMailbox.getTaskInfo(newTaskHash);
+        assertEq(task.executorCert, abi.encode(cert));
     }
 
     function test_Revert_WhenTimestampAtCreation() public {
@@ -922,6 +930,7 @@ contract TaskMailboxUnitTests_ViewFunctions is TaskMailboxUnitTests {
         assertEq(task.avsFee, avsFee);
         assertEq(task.feeSplit, 0);
         assertEq(task.payload, bytes("test payload"));
+        assertEq(task.executorCert, bytes(""));
         assertEq(task.result, bytes(""));
     }
 
@@ -1109,6 +1118,7 @@ contract TaskMailboxUnitTests_Storage is TaskMailboxUnitTests {
         assertEq(task.avsFee, avsFee);
         assertEq(task.feeSplit, 0);
         assertEq(task.payload, bytes("test payload"));
+        assertEq(task.executorCert, bytes(""));
         assertEq(task.result, bytes(""));
     }
 }

--- a/contracts/test/mocks/MockAVSTaskHook.sol
+++ b/contracts/test/mocks/MockAVSTaskHook.sol
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {IBN254CertificateVerifierTypes} from
-    "@eigenlayer-contracts/src/contracts/interfaces/IBN254CertificateVerifier.sol";
 import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
-
 import {IAVSTaskHook} from "../../src/interfaces/avs/l2/IAVSTaskHook.sol";
+import {ITaskMailboxTypes} from "../../src/interfaces/core/ITaskMailbox.sol";
 
 contract MockAVSTaskHook is IAVSTaskHook {
     function validatePreTaskCreation(
         address, /*caller*/
-        OperatorSet memory, /*operatorSet*/
-        bytes memory /*payload*/
+        ITaskMailboxTypes.TaskParams memory /*taskParams*/
     ) external view {
         //TODO: Implement
     }
@@ -22,7 +19,25 @@ contract MockAVSTaskHook is IAVSTaskHook {
         //TODO: Implement
     }
 
-    function handleTaskResultSubmission(bytes32, /*taskHash*/ bytes memory /*cert*/ ) external {
+    function validatePreTaskResultSubmission(
+        address, /*caller*/
+        bytes32, /*taskHash*/
+        bytes memory, /*cert*/
+        bytes memory /*result*/
+    ) external view {
+        //TODO: Implement
+    }
+
+    function handlePostTaskResultSubmission(
+        bytes32 /*taskHash*/
+    ) external {
+        //TODO: Implement
+    }
+
+    function calculateTaskFee(
+        OperatorSet memory, /*operatorSet*/
+        bytes memory /*payload*/
+    ) external view returns (uint96) {
         //TODO: Implement
     }
 }

--- a/contracts/test/mocks/ReentrantAttacker.sol
+++ b/contracts/test/mocks/ReentrantAttacker.sol
@@ -56,7 +56,7 @@ contract ReentrantAttacker is IAVSTaskHook, ITaskMailboxTypes {
         attackCreateTask = _attackCreateTask;
     }
 
-    function validatePreTaskCreation(address, OperatorSet memory, bytes memory) external view override {}
+    function validatePreTaskCreation(address, TaskParams memory) external view {}
 
     function handlePostTaskCreation(
         bytes32
@@ -88,7 +88,11 @@ contract ReentrantAttacker is IAVSTaskHook, ITaskMailboxTypes {
         }
     }
 
-    function handleTaskResultSubmission(bytes32, bytes memory) external {
+    function validatePreTaskResultSubmission(address, bytes32, bytes memory, bytes memory) external view {}
+
+    function handlePostTaskResultSubmission(
+        bytes32
+    ) external {
         if (!attackOnPost) {
             if (attackCreateTask) {
                 // Reconstruct TaskParams for the attack
@@ -114,5 +118,9 @@ contract ReentrantAttacker is IAVSTaskHook, ITaskMailboxTypes {
                 taskMailbox.submitResult(attackTaskHash, abi.encode(cert), result);
             }
         }
+    }
+
+    function calculateTaskFee(OperatorSet memory, bytes memory) external pure returns (uint96) {
+        return 0;
     }
 }


### PR DESCRIPTION
**Motivation:**

Cleaning up the TaskMailbox to make it simple to reason about and futureproofed.

**Modifications:**

* Removed `cancelTask`. Can be added later through an upgrade if necessary.
* Added `TaskStatus.NONE` to handle non-existent task case.
* Store cert verifiers as immutables (instead of mapping) since they don't change.
* Prefix internal variables with `_` to follow convention
* Updated Task Hook

**Result:**

Cleaner TaskMailbox