### PR TITLE
feat: generic executor consensus config

### DIFF
--- a/contracts/script/local/SetupAVSTaskMailboxConfig.s.sol
+++ b/contracts/script/local/SetupAVSTaskMailboxConfig.s.sol
@@ -29,7 +29,10 @@ contract SetupAVSTaskMailboxConfig is Script {
             feeToken: IERC20(address(0)),
             feeCollector: address(0),
             taskSLA: 60,
-            stakeProportionThreshold: 10_000,
+            consensus: ITaskMailboxTypes.Consensus({
+                consensusType: ITaskMailboxTypes.ConsensusType.STAKE_PROPORTION_THRESHOLD,
+                value: abi.encode(uint16(10_000))
+            }),
             taskMetadata: bytes("")
         });
         ITaskMailbox(taskMailbox).setExecutorOperatorSetTaskConfig(OperatorSet(avs, 1), executorOperatorSetTaskConfig);

--- a/contracts/script/local/StakeStuff.s.sol
+++ b/contracts/script/local/StakeStuff.s.sol
@@ -50,12 +50,6 @@ contract StakeStuff is Script {
 
         uint256 execStakerPrivateKey = vm.envUint("EXEC_STAKER_PRIVATE_KEY");
         address execStakerAddr = vm.addr(execStakerPrivateKey);
-
-        uint256 aggregatorPrivateKey = vm.envUint("AGGREGATOR_PRIVATE_KEY");
-        address aggregatorAddr = vm.addr(aggregatorPrivateKey);
-
-        uint256 executorPrivateKey = vm.envUint("EXECUTOR_PRIVATE_KEY");
-        address executorAddr = vm.addr(executorPrivateKey);
         // ... operator checks ...
 
         IERC20 wethToken = STRATEGY_WETH.underlyingToken();

--- a/contracts/script/local/WhitelistDevnet.s.sol
+++ b/contracts/script/local/WhitelistDevnet.s.sol
@@ -16,7 +16,6 @@ contract SetupAVSMultichain is Script {
     function setUp() public {}
 
     function run() public {
-        address ownerAddr = address(0xb094Ba769b4976Dc37fC689A76675f31bc4923b0);
         uint256 l1ChainId = uint256(vm.envUint("L1_CHAIN_ID"));
         uint256 l2ChainId = uint256(vm.envUint("L2_CHAIN_ID"));
 

--- a/contracts/src/core/TaskMailbox.sol
+++ b/contracts/src/core/TaskMailbox.sol
@@ -86,7 +86,7 @@ contract TaskMailbox is
         require(config.curveType != IKeyRegistrarTypes.CurveType.NONE, InvalidCurveType());
         require(config.taskHook != IAVSTaskHook(address(0)), InvalidAddressZero());
         require(config.taskSLA > 0, TaskSLAIsZero());
-        
+
         // Validate consensus configuration
         _validateConsensus(config.consensus);
 
@@ -265,12 +265,14 @@ contract TaskMailbox is
      * @notice Validates the consensus configuration
      * @param consensus The consensus configuration to validate
      */
-    function _validateConsensus(Consensus memory consensus) internal pure {
+    function _validateConsensus(
+        Consensus memory consensus
+    ) internal pure {
         if (consensus.consensusType == ConsensusType.STAKE_PROPORTION_THRESHOLD) {
             // Decode and validate the stake proportion threshold
             require(consensus.value.length == 32, InvalidConsensusValue());
             uint16 stakeProportionThreshold = abi.decode(consensus.value, (uint16));
-            require(stakeProportionThreshold <= 10000, InvalidConsensusValue());
+            require(stakeProportionThreshold <= 10_000, InvalidConsensusValue());
         } else {
             revert InvalidConsensusType();
         }
@@ -295,7 +297,7 @@ contract TaskMailbox is
             uint16 stakeProportionThreshold = abi.decode(consensus.value, (uint16));
             uint16[] memory totalStakeProportionThresholds = new uint16[](1);
             totalStakeProportionThresholds[0] = stakeProportionThreshold;
-            
+
             // Verify certificate based on curve type
             if (curveType == IKeyRegistrarTypes.CurveType.BN254) {
                 // BN254 Certificate verification

--- a/contracts/src/core/TaskMailbox.sol
+++ b/contracts/src/core/TaskMailbox.sol
@@ -76,7 +76,6 @@ contract TaskMailbox is
         OperatorSet memory operatorSet,
         ExecutorOperatorSetTaskConfig memory config
     ) external {
-        // TODO: Double check if any other config checks are needed.
         require(config.curveType != IKeyRegistrarTypes.CurveType.NONE, InvalidCurveType());
         require(config.taskHook != IAVSTaskHook(address(0)), InvalidAddressZero());
         require(config.taskSLA > 0, TaskSLAIsZero());
@@ -102,7 +101,7 @@ contract TaskMailbox is
 
         require(
             taskConfig.curveType != IKeyRegistrarTypes.CurveType.NONE && address(taskConfig.taskHook) != address(0)
-                && taskConfig.taskSLA > 0,
+                && taskConfig.taskSLA > 0 && taskConfig.consensus.consensusType != ConsensusType.NONE,
             ExecutorOperatorSetTaskConfigNotSet()
         );
 
@@ -125,7 +124,7 @@ contract TaskMailbox is
             executorOperatorSetTaskConfigs[taskParams.executorOperatorSet.key()];
         require(
             taskConfig.curveType != IKeyRegistrarTypes.CurveType.NONE && address(taskConfig.taskHook) != address(0)
-                && taskConfig.taskSLA > 0,
+                && taskConfig.taskSLA > 0 && taskConfig.consensus.consensusType != ConsensusType.NONE,
             ExecutorOperatorSetTaskConfigNotSet()
         );
 

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -270,10 +270,10 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
     /**
      * @notice Submits the result of a task execution
      * @param taskHash Unique identifier of the task
-     * @param cert Certificate proving the validity of the result
+     * @param executorCert Certificate proving the validity of the result
      * @param result Task execution result data
      */
-    function submitResult(bytes32 taskHash, bytes memory cert, bytes memory result) external;
+    function submitResult(bytes32 taskHash, bytes memory executorCert, bytes memory result) external;
 
     /**
      *

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -246,6 +246,7 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
      * @notice Sets the task configuration for an executor operator set
      * @param operatorSet The operator set to configure
      * @param config Task configuration for the operator set
+     * @dev Fees can be switched off by setting the fee token to the zero address.
      */
     function setExecutorOperatorSetTaskConfig(
         OperatorSet memory operatorSet,
@@ -256,6 +257,7 @@ interface ITaskMailbox is ITaskMailboxErrors, ITaskMailboxEvents {
      * @notice Registers an executor operator set with the TaskMailbox
      * @param operatorSet The operator set to register
      * @param isRegistered Whether the operator set is registered
+     * @dev This function can be called to toggle the registration once the task config has been set.
      */
     function registerExecutorOperatorSet(OperatorSet memory operatorSet, bool isRegistered) external;
 

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -17,13 +17,30 @@ import {IAVSTaskHook} from "../avs/l2/IAVSTaskHook.sol";
  */
 interface ITaskMailboxTypes {
     /**
+     * @notice Enum defining the type of consensus mechanism
+     */
+    enum ConsensusType {
+        STAKE_PROPORTION_THRESHOLD
+    }
+
+    /**
+     * @notice Consensus configuration for task verification
+     * @param consensusType The type of consensus mechanism
+     * @param value Encoded consensus parameters based on consensusType
+     */
+    struct Consensus {
+        ConsensusType consensusType;
+        bytes value;
+    }
+
+    /**
      * @notice Configuration for the executor operator set
      * @param curveType The curve type used for signature verification
      * @param taskHook Address of the AVS task hook contract
      * @param feeToken ERC20 token used for task fees
      * @param feeCollector Address to receive AVS fees
      * @param taskSLA Time (in seconds) within which the task must be completed
-     * @param stakeProportionThreshold Minimum proportion of executor operator set stake required to certify task execution (in basis points)
+     * @param consensus Consensus configuration for task verification
      * @param taskMetadata Additional metadata for task execution
      */
     struct ExecutorOperatorSetTaskConfig {
@@ -34,7 +51,7 @@ interface ITaskMailboxTypes {
         IERC20 feeToken;
         address feeCollector;
         uint96 taskSLA;
-        uint16 stakeProportionThreshold;
+        Consensus consensus;
         bytes taskMetadata;
     }
 
@@ -134,6 +151,12 @@ interface ITaskMailboxErrors is ITaskMailboxTypes {
 
     /// @notice Thrown when an operator set owner is invalid
     error InvalidOperatorSetOwner();
+
+    /// @notice Thrown when an invalid consensus type is provided
+    error InvalidConsensusType();
+
+    /// @notice Thrown when an invalid consensus value is provided
+    error InvalidConsensusValue();
 }
 
 /**

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -17,16 +17,6 @@ import {IAVSTaskHook} from "../avs/l2/IAVSTaskHook.sol";
  */
 interface ITaskMailboxTypes {
     /**
-     * @notice Configuration for certificate verifiers
-     * @param curveType The curve type for the verifier
-     * @param verifier Address of the certificate verifier contract
-     */
-    struct CertificateVerifierConfig {
-        IKeyRegistrarTypes.CurveType curveType;
-        address verifier;
-    }
-
-    /**
      * @notice Configuration for the executor operator set
      * @param curveType The curve type used for signature verification
      * @param taskHook Address of the AVS task hook contract

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -45,7 +45,6 @@ interface ITaskMailboxTypes {
      */
     struct ExecutorOperatorSetTaskConfig {
         // TODO: Pack storage efficiently.
-        // TODO: We need to support proportional, nominal, none and custom verifications.
         IKeyRegistrarTypes.CurveType curveType;
         IAVSTaskHook taskHook;
         IERC20 feeToken;

--- a/contracts/src/interfaces/core/ITaskMailbox.sol
+++ b/contracts/src/interfaces/core/ITaskMailbox.sol
@@ -20,6 +20,7 @@ interface ITaskMailboxTypes {
      * @notice Enum defining the type of consensus mechanism
      */
     enum ConsensusType {
+        NONE,
         STAKE_PROPORTION_THRESHOLD
     }
 

--- a/contracts/test/TaskMailbox.t.sol
+++ b/contracts/test/TaskMailbox.t.sol
@@ -437,6 +437,19 @@ contract TaskMailboxUnitTests_setExecutorOperatorSetTaskConfig is TaskMailboxUni
         uint16 decodedThreshold = abi.decode(retrievedConfig.consensus.value, (uint16));
         assertEq(decodedThreshold, 10_000);
     }
+
+    function test_Revert_WhenConsensusTypeIsNone() public {
+        OperatorSet memory operatorSet = OperatorSet(avs, executorOperatorSetId);
+        ExecutorOperatorSetTaskConfig memory config = _createValidExecutorOperatorSetTaskConfig();
+        config.consensus = Consensus({
+            consensusType: ConsensusType.NONE,
+            value: bytes("") // Empty value for NONE type
+        });
+
+        vm.prank(avs);
+        vm.expectRevert(InvalidConsensusType.selector);
+        taskMailbox.setExecutorOperatorSetTaskConfig(operatorSet, config);
+    }
 }
 
 // Test contract for createTask


### PR DESCRIPTION
**Motivation:**

We need to support generic executor consensus configurations (rather than just stake proportional threshold).

**Modifications:**

Refactored the Mailbox such that we can support other consensus types per executor operator set in the future.

**Result:**

Cleaner consensus configuration