### PR TITLE
feat: kill anvil and wait to cleanup

### DIFF
--- a/ponos/internal/testUtils/testUtils.go
+++ b/ponos/internal/testUtils/testUtils.go
@@ -129,6 +129,16 @@ func WaitForAnvil(
 	}
 }
 
+func KillallAnvils() error {
+	cmd := exec.Command("pkill", "-f", "anvil")
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to kill all anvils: %w", err)
+	}
+	fmt.Println("All anvil processes killed successfully")
+	return nil
+}
+
 func StartL1Anvil(projectRoot string, ctx context.Context) (*exec.Cmd, error) {
 	forkUrl := "https://practical-serene-mound.ethereum-sepolia.quiknode.pro/3aaa48bd95f3d6aed60e89a1a466ed1e2a440b61/"
 	portNumber := "8545"

--- a/ponos/internal/testUtils/testUtils.go
+++ b/ponos/internal/testUtils/testUtils.go
@@ -238,6 +238,20 @@ func StartAnvil(projectRoot string, ctx context.Context, cfg *AnvilConfig) (*exe
 	return nil, fmt.Errorf("failed to start anvil")
 }
 
+func KillAnvil(cmd *exec.Cmd) error {
+	if cmd == nil || cmd.Process == nil {
+		return fmt.Errorf("anvil command is not running")
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("failed to kill anvil process: %w", err)
+	}
+	_ = cmd.Wait()
+
+	fmt.Println("Anvil process killed successfully")
+	return nil
+}
+
 func ReadMailboxAbiJson(projectRoot string) ([]byte, error) {
 	// read the mailbox ABI json file
 	path, err := filepath.Abs(fmt.Sprintf("%s/../contracts/out/ITaskMailbox.sol/ITaskMailbox.json", projectRoot))

--- a/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
+++ b/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
@@ -83,6 +83,8 @@ func Test_CertificateVerifier(t *testing.T) {
 	anvilWg.Add(1)
 	startErrorsChan := make(chan error, 1)
 
+	_ = testUtils.KillallAnvils()
+
 	l1Anvil, err := testUtils.StartL1Anvil(root, ctx)
 	if err != nil {
 		t.Fatalf("Failed to start L1 Anvil: %v", err)

--- a/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
+++ b/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
@@ -340,6 +340,6 @@ func Test_CertificateVerifier(t *testing.T) {
 	t.Logf("Certificate verification receipt: %+v", receipt)
 
 	t.Cleanup(func() {
-		_ = l1Anvil.Process.Kill()
+		_ = testUtils.KillAnvil(l1Anvil)
 	})
 }

--- a/ponos/internal/tests/mailbox/mailbox_integration_test.go
+++ b/ponos/internal/tests/mailbox/mailbox_integration_test.go
@@ -136,6 +136,8 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 	anvilCtx, anvilCancel := context.WithDeadline(ctx, time.Now().Add(10*time.Second))
 	defer anvilCancel()
 
+	_ = testUtils.KillallAnvils()
+
 	l1Anvil, err := testUtils.StartL1Anvil(root, ctx)
 	if err != nil {
 		t.Fatalf("Failed to start L1 Anvil: %v", err)

--- a/ponos/internal/tests/mailbox/mailbox_integration_test.go
+++ b/ponos/internal/tests/mailbox/mailbox_integration_test.go
@@ -509,9 +509,9 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 
 	assert.False(t, hasErrors)
 
-	_ = l1Anvil.Process.Kill()
+	_ = testUtils.KillAnvil(l1Anvil)
 	if l2Anvil != nil {
-		_ = l2Anvil.Process.Kill()
+		_ = testUtils.KillAnvil(l2Anvil)
 	}
 }
 

--- a/ponos/pkg/aggregator/aggregator_test.go
+++ b/ponos/pkg/aggregator/aggregator_test.go
@@ -132,6 +132,8 @@ func Test_Aggregator(t *testing.T) {
 		t.Fatalf("Failed to get Ethereum contract caller: %v", err)
 	}
 
+	_ = testUtils.KillallAnvils()
+
 	startErrorsChan := make(chan error, 2)
 	anvilCtx, anvilCancel := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
 	defer anvilCancel()

--- a/ponos/pkg/aggregator/aggregator_test.go
+++ b/ponos/pkg/aggregator/aggregator_test.go
@@ -503,8 +503,8 @@ func Test_Aggregator(t *testing.T) {
 	time.Sleep(5 * time.Second)
 	assert.True(t, taskVerified)
 
-	_ = l1Anvil.Process.Kill()
-	_ = l2Anvil.Process.Kill()
+	_ = testUtils.KillAnvil(l1Anvil)
+	_ = testUtils.KillAnvil(l2Anvil)
 	cancel()
 }
 

--- a/ponos/pkg/executor/executor_test.go
+++ b/ponos/pkg/executor/executor_test.go
@@ -279,7 +279,7 @@ func testWithKeyType(
 	<-ctx.Done()
 	t.Logf("Received shutdown signal, shutting down...")
 
-	_ = l1Anvil.Process.Kill()
+	_ = testUtils.KillAnvil(l1Anvil)
 }
 
 func Test_Executor(t *testing.T) {

--- a/ponos/pkg/executor/executor_test.go
+++ b/ponos/pkg/executor/executor_test.go
@@ -97,6 +97,8 @@ func testWithKeyType(
 		t.Fatalf("Failed to get L1 Ethereum contract caller: %v", err)
 	}
 
+	_ = testUtils.KillallAnvils()
+
 	anvilWg := &sync.WaitGroup{}
 	anvilWg.Add(1)
 	startErrorsChan := make(chan error, 1)

--- a/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
+++ b/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
@@ -216,7 +216,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 			t.Logf("Test completed")
 		}
 
-		_ = anvil.Process.Kill()
+		_ = testUtils.KillAnvil(anvil)
 		assert.False(t, hasErrors)
 	})
 
@@ -431,7 +431,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 		}
 
 		assert.False(t, hasErrors)
-		_ = anvil.Process.Kill()
+		_ = testUtils.KillAnvil(anvil)
 	})
 
 }

--- a/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
+++ b/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
@@ -70,6 +70,8 @@ func Test_PeeringDataFetcher(t *testing.T) {
 			l.Sugar().Fatalf("failed to get Ethereum contract caller: %v", err)
 		}
 
+		_ = testUtils.KillallAnvils()
+
 		anvil, err := testUtils.StartL1Anvil(root, ctx)
 		if err != nil {
 			t.Fatalf("Failed to start Anvil: %v", err)


### PR DESCRIPTION
`Process.Kill()` simply sends a kill signal and doesnt wait, resulting in tests flaking out occasionally. This will now run `Process.Kill()` and then `Process.Wait()` to wait on it to actually shutdown before proceeding.