### PR TITLE
feat: removing avs registrar avs performers required parameter for exe and agg

### DIFF
--- a/ponos/cmd/aggregator/run.go
+++ b/ponos/cmd/aggregator/run.go
@@ -86,7 +86,6 @@ var runCmd = &cobra.Command{
 				RpcURL:  l1Chain.RpcURL,
 			},
 			Config.Operator.OperatorPrivateKey,
-			Config.Avss[0].AVSRegistrarAddress,
 			l,
 		)
 		if err != nil {

--- a/ponos/cmd/executor/run.go
+++ b/ponos/cmd/executor/run.go
@@ -102,9 +102,7 @@ var runCmd = &cobra.Command{
 			return fmt.Errorf("failed to create private key signer: %w", err)
 		}
 
-		cc, err := caller.NewContractCallerFromEthereumClient(&caller.ContractCallerConfig{
-			AVSRegistrarAddress: Config.AvsPerformers[0].AVSRegistrarAddress,
-		}, ethereumClient, privateKeySigner, l)
+		cc, err := caller.NewContractCallerFromEthereumClient(ethereumClient, privateKeySigner, l)
 		if err != nil {
 			return fmt.Errorf("failed to initialize contract caller: %w", err)
 		}

--- a/ponos/cmd/mailbox/main.go
+++ b/ponos/cmd/mailbox/main.go
@@ -43,9 +43,7 @@ func main() {
 		panic(err)
 	}
 
-	cc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: "0x5897a9b8b746c78e0cae876962796949832e3357",
-	}, ethCaller, privateKeySigner, l)
+	cc, err := caller.NewContractCaller(ethCaller, privateKeySigner, l)
 	if err != nil {
 		panic(err)
 	}

--- a/ponos/internal/testUtils/operators.go
+++ b/ponos/internal/testUtils/operators.go
@@ -38,9 +38,7 @@ func SetupOperatorPeering(
 		return fmt.Errorf("failed to create AVS private key signer: %v", err)
 	}
 
-	avsCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, ethClient, avsPrivateKeySigner, l)
+	avsCc, err := caller.NewContractCaller(ethClient, avsPrivateKeySigner, l)
 	if err != nil {
 		return fmt.Errorf("failed to create AVS contract caller: %v", err)
 	}
@@ -50,9 +48,7 @@ func SetupOperatorPeering(
 		return fmt.Errorf("failed to create aggregator private key signer: %v", err)
 	}
 
-	aggregatorCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, ethClient, aggregatorPrivateKeySigner, l)
+	aggregatorCc, err := caller.NewContractCaller(ethClient, aggregatorPrivateKeySigner, l)
 	if err != nil {
 		return fmt.Errorf("failed to create aggregator contract caller: %v", err)
 	}
@@ -90,9 +86,7 @@ func SetupOperatorPeering(
 		return fmt.Errorf("failed to create executor private key signer: %v", err)
 	}
 
-	executorCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, ethClient, executorPrivateKeySigner, l)
+	executorCc, err := caller.NewContractCaller(ethClient, executorPrivateKeySigner, l)
 	if err != nil {
 		return fmt.Errorf("failed to create executor contract caller: %v", err)
 	}
@@ -211,7 +205,7 @@ func DelegateStakeToOperator(
 		return fmt.Errorf("failed to create staker private key signer: %v", err)
 	}
 
-	stakerCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{}, ethclient, stakerPrivateKeySigner, l)
+	stakerCc, err := caller.NewContractCaller(ethclient, stakerPrivateKeySigner, l)
 	if err != nil {
 		return fmt.Errorf("failed to create staker contract caller: %v", err)
 	}
@@ -229,7 +223,7 @@ func DelegateStakeToOperator(
 		return fmt.Errorf("failed to create operator private key signer: %v", err)
 	}
 
-	opCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{}, ethclient, opPrivateKeySigner, l)
+	opCc, err := caller.NewContractCaller(ethclient, opPrivateKeySigner, l)
 	if err != nil {
 		return fmt.Errorf("failed to create operator contract caller: %v", err)
 	}

--- a/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
+++ b/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
@@ -112,9 +112,7 @@ func Test_CertificateVerifier(t *testing.T) {
 		t.Fatalf("Failed to create L1 private key signer: %v", err)
 	}
 
-	l1CC, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress, // technically not used...
-	}, l1EthClient, l1PrivateKeySigner, l)
+	l1CC, err := caller.NewContractCaller(l1EthClient, l1PrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create L2 contract caller: %v", err)
 	}

--- a/ponos/internal/tests/mailbox/mailbox_integration_test.go
+++ b/ponos/internal/tests/mailbox/mailbox_integration_test.go
@@ -177,9 +177,7 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 		t.Fatalf("Failed to create L1 private key signer: %v", err)
 	}
 
-	l1CC, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress, // technically not used...
-	}, l1EthClient, l1PrivateKeySigner, l)
+	l1CC, err := caller.NewContractCaller(l1EthClient, l1PrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create L2 contract caller: %v", err)
 	}
@@ -191,9 +189,7 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 			t.Fatalf("Failed to create L2 private key signer: %v", err)
 		}
 
-		l2CC, err = caller.NewContractCaller(&caller.ContractCallerConfig{
-			AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress, // technically not used...
-		}, l2EthClient, l2PrivateKeySigner, l)
+		l2CC, err = caller.NewContractCaller(l2EthClient, l2PrivateKeySigner, l)
 		if err != nil {
 			t.Fatalf("Failed to create L2 contract caller: %v", err)
 		}
@@ -302,9 +298,7 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 		t.Fatalf("Failed to create AVS private key signer: %v", err)
 	}
 
-	avsCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, mailboxEthClient, avsPrivateKeySigner, l)
+	avsCc, err := caller.NewContractCaller(mailboxEthClient, avsPrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create AVS contract caller: %v", err)
 	}

--- a/ponos/pkg/aggregator/aggregator.go
+++ b/ponos/pkg/aggregator/aggregator.go
@@ -201,7 +201,6 @@ func (a *Aggregator) initializePollers() error {
 func InitializeContractCaller(
 	chain *aggregatorConfig.Chain,
 	privateKeyConfig *config.ECDSAKeyConfig,
-	avsRegistrarAddress string,
 	logger *zap.Logger,
 ) (contractCaller.IContractCaller, error) {
 	ec := ethereum.NewEthereumClient(&ethereum.EthereumClientConfig{
@@ -221,11 +220,7 @@ func InitializeContractCaller(
 		return nil, fmt.Errorf("failed to create transactionSigner: %w", err)
 	}
 
-	callerConfig := &caller.ContractCallerConfig{
-		AVSRegistrarAddress: avsRegistrarAddress,
-	}
-
-	return caller.NewContractCaller(callerConfig, ethereumContractCaller, txSigner, logger)
+	return caller.NewContractCaller(ethereumContractCaller, txSigner, logger)
 }
 
 func (a *Aggregator) initializeContractCallers() (map[config.ChainId]contractCaller.IContractCaller, error) {
@@ -233,12 +228,7 @@ func (a *Aggregator) initializeContractCallers() (map[config.ChainId]contractCal
 	contractCallers := make(map[config.ChainId]contractCaller.IContractCaller)
 	for _, chain := range a.config.Chains {
 
-		cc, err := InitializeContractCaller(
-			chain,
-			a.config.PrivateKeyConfig,
-			a.config.AVSs[0].AVSRegistrarAddress,
-			a.logger,
-		)
+		cc, err := InitializeContractCaller(chain, a.config.PrivateKeyConfig, a.logger)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize contract caller for chain %s: %w", chain.Name, err)
 		}

--- a/ponos/pkg/aggregator/aggregatorConfig/aggregatorConfig.go
+++ b/ponos/pkg/aggregator/aggregatorConfig/aggregatorConfig.go
@@ -46,18 +46,14 @@ func (c *Chain) IsAnvilRpc() bool {
 }
 
 type AggregatorAvs struct {
-	Address             string `json:"address" yaml:"address"`
-	ChainIds            []uint `json:"chainIds" yaml:"chainIds"`
-	AVSRegistrarAddress string `json:"avsRegistrarAddress" yaml:"avsRegistrarAddress"`
+	Address  string `json:"address" yaml:"address"`
+	ChainIds []uint `json:"chainIds" yaml:"chainIds"`
 }
 
 func (aa *AggregatorAvs) Validate() error {
 	var allErrors field.ErrorList
 	if aa.Address == "" {
 		allErrors = append(allErrors, field.Required(field.NewPath("address"), "address is required"))
-	}
-	if aa.AVSRegistrarAddress == "" {
-		allErrors = append(allErrors, field.Required(field.NewPath("avsRegistrarAddress"), "avsRegistrarAddress is required"))
 	}
 	if len(allErrors) > 0 {
 		return allErrors.ToAggregate()

--- a/ponos/pkg/aggregator/aggregator_test.go
+++ b/ponos/pkg/aggregator/aggregator_test.go
@@ -183,7 +183,6 @@ func runAggregatorTest(t *testing.T, mode string) {
 		PrivateKey: chainConfig.OperatorAccountPrivateKey,
 	}
 	aggConfig.Avss[0].Address = chainConfig.AVSAccountAddress
-	aggConfig.Avss[0].AVSRegistrarAddress = chainConfig.AVSTaskRegistrarAddress
 	aggConfig.Avss[0].ChainIds = []uint{
 		uint(config.ChainId_BaseSepoliaAnvil),
 	}
@@ -284,9 +283,7 @@ func runAggregatorTest(t *testing.T, mode string) {
 		t.Fatalf("Failed to create L1 aggregator private key bn254Signer: %v", err)
 	}
 
-	l1AggCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, l1EthClient, l1AggPrivateKeySigner, l)
+	l1AggCc, err := caller.NewContractCaller(l1EthClient, l1AggPrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create contract caller: %v", err)
 	}
@@ -296,9 +293,7 @@ func runAggregatorTest(t *testing.T, mode string) {
 		t.Fatalf("Failed to create L1 executor private key bn254Signer: %v", err)
 	}
 
-	l1ExecCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, l1EthClient, l1ExecPrivateKeySigner, l)
+	l1ExecCc, err := caller.NewContractCaller(l1EthClient, l1ExecPrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create contract caller: %v", err)
 	}
@@ -400,9 +395,7 @@ func runAggregatorTest(t *testing.T, mode string) {
 		t.Fatalf("Failed to create AVS L1 private key bn254Signer: %v", err)
 	}
 
-	avsCcL1, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, l1EthClient, avsCcL1PrivateKeySigner, l)
+	avsCcL1, err := caller.NewContractCaller(l1EthClient, avsCcL1PrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create AVS contract caller: %v", err)
 	}
@@ -423,9 +416,7 @@ func runAggregatorTest(t *testing.T, mode string) {
 		t.Fatalf("Failed to create AVS L2 private key bn254Signer: %v", err)
 	}
 
-	avsCcL2, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, l2EthClient, avsCcL2PrivateKeySigner, l)
+	avsCcL2, err := caller.NewContractCaller(l2EthClient, avsCcL2PrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create AVS contract caller: %v", err)
 	}
@@ -582,9 +573,7 @@ func runAggregatorTest(t *testing.T, mode string) {
 		t.Fatalf("Failed to create L2 app private key bn254Signer: %v", err)
 	}
 
-	l2AppCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-	}, l2EthClient, l2AppPrivateKeySigner, l)
+	l2AppCc, err := caller.NewContractCaller(l2EthClient, l2AppPrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create contract caller: %v", err)
 	}

--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -33,26 +33,25 @@ import (
 )
 
 type ContractCallerConfig struct {
-	AVSRegistrarAddress string
+	// No longer need AVS registrar address at construction time
 }
 
 type ContractCaller struct {
-	avsRegistrarCaller *TaskAVSRegistrarBase.TaskAVSRegistrarBaseCaller
-	taskMailbox        *ITaskMailbox.ITaskMailbox
-	allocationManager  *IAllocationManager.IAllocationManager
-	delegationManager  *IDelegationManager.IDelegationManager
-	crossChainRegistry *ICrossChainRegistry.ICrossChainRegistry
-	keyRegistrar       *IKeyRegistrar.IKeyRegistrar
-	ecdsaCertVerifier  *IECDSACertificateVerifier.IECDSACertificateVerifier
-	ethclient          *ethclient.Client
-	config             *ContractCallerConfig
-	logger             *zap.Logger
-	coreContracts      *config.CoreContractAddresses
-	signer             transactionSigner.ITransactionSigner
+	// AVS registrar callers are now created per-call as needed
+	avsRegistrarCallers map[string]*TaskAVSRegistrarBase.TaskAVSRegistrarBaseCaller
+	taskMailbox         *ITaskMailbox.ITaskMailbox
+	allocationManager   *IAllocationManager.IAllocationManager
+	delegationManager   *IDelegationManager.IDelegationManager
+	crossChainRegistry  *ICrossChainRegistry.ICrossChainRegistry
+	keyRegistrar        *IKeyRegistrar.IKeyRegistrar
+	ecdsaCertVerifier   *IECDSACertificateVerifier.IECDSACertificateVerifier
+	ethclient           *ethclient.Client
+	logger              *zap.Logger
+	coreContracts       *config.CoreContractAddresses
+	signer              transactionSigner.ITransactionSigner
 }
 
 func NewContractCallerFromEthereumClient(
-	config *ContractCallerConfig,
 	ethClient *ethereum.Client,
 	signer transactionSigner.ITransactionSigner,
 	logger *zap.Logger,
@@ -62,22 +61,15 @@ func NewContractCallerFromEthereumClient(
 		return nil, err
 	}
 
-	return NewContractCaller(config, client, signer, logger)
+	return NewContractCaller(client, signer, logger)
 }
 
 func NewContractCaller(
-	cfg *ContractCallerConfig,
 	ethclient *ethclient.Client,
 	signer transactionSigner.ITransactionSigner,
 	logger *zap.Logger,
 ) (*ContractCaller, error) {
-	logger.Sugar().Debugw("Creating contract caller",
-		zap.String("AVSRegistrarAddress", cfg.AVSRegistrarAddress),
-	)
-	avsRegistrarCaller, err := TaskAVSRegistrarBase.NewTaskAVSRegistrarBaseCaller(common.HexToAddress(cfg.AVSRegistrarAddress), ethclient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create AVSRegistrar caller: %w", err)
-	}
+	logger.Sugar().Debugw("Creating contract caller")
 
 	chainId, err := ethclient.ChainID(context.Background())
 	if err != nil {
@@ -120,19 +112,43 @@ func NewContractCaller(
 	}
 
 	return &ContractCaller{
-		avsRegistrarCaller: avsRegistrarCaller,
-		taskMailbox:        taskMailbox,
-		allocationManager:  allocationManager,
-		keyRegistrar:       keyRegistrar,
-		delegationManager:  delegationManager,
-		crossChainRegistry: crossChainRegistry,
-		ecdsaCertVerifier:  ecdsaCertVerifier,
-		ethclient:          ethclient,
-		coreContracts:      coreContracts,
-		config:             cfg,
-		logger:             logger,
-		signer:             signer,
+		avsRegistrarCallers: make(map[string]*TaskAVSRegistrarBase.TaskAVSRegistrarBaseCaller),
+		taskMailbox:         taskMailbox,
+		allocationManager:   allocationManager,
+		keyRegistrar:        keyRegistrar,
+		delegationManager:   delegationManager,
+		crossChainRegistry:  crossChainRegistry,
+		ecdsaCertVerifier:   ecdsaCertVerifier,
+		ethclient:           ethclient,
+		coreContracts:       coreContracts,
+		logger:              logger,
+		signer:              signer,
 	}, nil
+}
+
+// getAVSRegistrarCaller gets or creates an AVS registrar caller for the given AVS address
+func (cc *ContractCaller) getAVSRegistrarCaller(avsAddress string) (*TaskAVSRegistrarBase.TaskAVSRegistrarBaseCaller, error) {
+	// Check cache first
+	if caller, ok := cc.avsRegistrarCallers[avsAddress]; ok {
+		return caller, nil
+	}
+
+	// Get the AVS registrar address from the allocation manager
+	avsAddr := common.HexToAddress(avsAddress)
+	avsRegistrarAddress, err := cc.allocationManager.GetAVSRegistrar(&bind.CallOpts{}, avsAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AVS registrar address: %w", err)
+	}
+
+	// Create new caller
+	caller, err := TaskAVSRegistrarBase.NewTaskAVSRegistrarBaseCaller(avsRegistrarAddress, cc.ethclient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AVS registrar caller: %w", err)
+	}
+
+	// Cache it
+	cc.avsRegistrarCallers[avsAddress] = caller
+	return caller, nil
 }
 
 func (cc *ContractCaller) SubmitBN254TaskResultRetryable(
@@ -369,8 +385,11 @@ func (cc *ContractCaller) GetOperatorSetDetailsForOperator(operatorAddress commo
 		Avs: common.HexToAddress(avsAddress),
 		Id:  operatorSetId,
 	}
-
-	socket, err := cc.avsRegistrarCaller.GetOperatorSocket(&bind.CallOpts{}, operatorAddress)
+	avsRegistrarCaller, err := cc.getAVSRegistrarCaller(avsAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AVSRegistrar caller: %w", err)
+	}
+	socket, err := avsRegistrarCaller.GetOperatorSocket(&bind.CallOpts{}, operatorAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operator socket: %w", err)
 	}

--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -32,10 +32,6 @@ import (
 	"time"
 )
 
-type ContractCallerConfig struct {
-	// No longer need AVS registrar address at construction time
-}
-
 type ContractCaller struct {
 	taskMailbox        *ITaskMailbox.ITaskMailbox
 	allocationManager  *IAllocationManager.IAllocationManager

--- a/ponos/pkg/executor/executorConfig/executorConfig_test.go
+++ b/ponos/pkg/executor/executorConfig/executorConfig_test.go
@@ -59,9 +59,8 @@ func Test_ExecutorConfig(t *testing.T) {
 func TestDeploymentMode(t *testing.T) {
 	t.Run("Should default to docker mode when not specified", func(t *testing.T) {
 		config := &AvsPerformerConfig{
-			AvsAddress:          "0x123",
-			ProcessType:         "server",
-			AVSRegistrarAddress: "0x456",
+			AvsAddress:  "0x123",
+			ProcessType: "server",
 			Image: &PerformerImage{
 				Repository: "test/image",
 				Tag:        "v1.0.0",
@@ -75,10 +74,9 @@ func TestDeploymentMode(t *testing.T) {
 
 	t.Run("Should accept kubernetes mode", func(t *testing.T) {
 		config := &AvsPerformerConfig{
-			AvsAddress:          "0x123",
-			ProcessType:         "server",
-			AVSRegistrarAddress: "0x456",
-			DeploymentMode:      DeploymentModeKubernetes,
+			AvsAddress:     "0x123",
+			ProcessType:    "server",
+			DeploymentMode: DeploymentModeKubernetes,
 			Image: &PerformerImage{
 				Repository: "test/image",
 				Tag:        "v1.0.0",
@@ -92,10 +90,9 @@ func TestDeploymentMode(t *testing.T) {
 
 	t.Run("Should reject invalid deployment mode", func(t *testing.T) {
 		config := &AvsPerformerConfig{
-			AvsAddress:          "0x123",
-			ProcessType:         "server",
-			AVSRegistrarAddress: "0x456",
-			DeploymentMode:      "invalid",
+			AvsAddress:     "0x123",
+			ProcessType:    "server",
+			DeploymentMode: "invalid",
 			Image: &PerformerImage{
 				Repository: "test/image",
 				Tag:        "v1.0.0",
@@ -182,10 +179,9 @@ func TestExecutorConfigKubernetes(t *testing.T) {
 			},
 			AvsPerformers: []*AvsPerformerConfig{
 				{
-					AvsAddress:          "0x456",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0x789",
-					DeploymentMode:      DeploymentModeKubernetes,
+					AvsAddress:     "0x456",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeKubernetes,
 					Image: &PerformerImage{
 						Repository: "test/image",
 						Tag:        "v1.0.0",
@@ -219,10 +215,9 @@ func TestExecutorConfigKubernetes(t *testing.T) {
 			},
 			AvsPerformers: []*AvsPerformerConfig{
 				{
-					AvsAddress:          "0x456",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0x789",
-					DeploymentMode:      DeploymentModeKubernetes,
+					AvsAddress:     "0x456",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeKubernetes,
 					Image: &PerformerImage{
 						Repository: "test/image",
 						Tag:        "v1.0.0",
@@ -256,20 +251,18 @@ func TestExecutorConfigKubernetes(t *testing.T) {
 			},
 			AvsPerformers: []*AvsPerformerConfig{
 				{
-					AvsAddress:          "0x456",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0x789",
-					DeploymentMode:      DeploymentModeDocker,
+					AvsAddress:     "0x456",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeDocker,
 					Image: &PerformerImage{
 						Repository: "test/image",
 						Tag:        "v1.0.0",
 					},
 				},
 				{
-					AvsAddress:          "0xabc",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0xdef",
-					DeploymentMode:      DeploymentModeKubernetes,
+					AvsAddress:     "0xabc",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeKubernetes,
 					Image: &PerformerImage{
 						Repository: "test/image2",
 						Tag:        "v1.0.0",
@@ -482,20 +475,18 @@ func TestMixedDeploymentModeValidation(t *testing.T) {
 			},
 			AvsPerformers: []*AvsPerformerConfig{
 				{
-					AvsAddress:          "0x456",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0x789",
-					DeploymentMode:      DeploymentModeDocker, // Docker mode
+					AvsAddress:     "0x456",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeDocker, // Docker mode
 					Image: &PerformerImage{
 						Repository: "test/image",
 						Tag:        "v1.0.0",
 					},
 				},
 				{
-					AvsAddress:          "0xabc",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0xdef",
-					DeploymentMode:      DeploymentModeKubernetes, // Kubernetes mode
+					AvsAddress:     "0xabc",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeKubernetes, // Kubernetes mode
 					Image: &PerformerImage{
 						Repository: "test/image2",
 						Tag:        "v1.0.0",
@@ -529,20 +520,18 @@ func TestMixedDeploymentModeValidation(t *testing.T) {
 			},
 			AvsPerformers: []*AvsPerformerConfig{
 				{
-					AvsAddress:          "0x456",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0x789",
-					DeploymentMode:      DeploymentModeDocker,
+					AvsAddress:     "0x456",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeDocker,
 					Image: &PerformerImage{
 						Repository: "test/image",
 						Tag:        "v1.0.0",
 					},
 				},
 				{
-					AvsAddress:          "0xabc",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0xdef",
-					DeploymentMode:      DeploymentModeDocker,
+					AvsAddress:     "0xabc",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeDocker,
 					Image: &PerformerImage{
 						Repository: "test/image2",
 						Tag:        "v1.0.0",
@@ -575,20 +564,18 @@ func TestMixedDeploymentModeValidation(t *testing.T) {
 			},
 			AvsPerformers: []*AvsPerformerConfig{
 				{
-					AvsAddress:          "0x456",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0x789",
-					DeploymentMode:      DeploymentModeKubernetes,
+					AvsAddress:     "0x456",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeKubernetes,
 					Image: &PerformerImage{
 						Repository: "test/image",
 						Tag:        "v1.0.0",
 					},
 				},
 				{
-					AvsAddress:          "0xabc",
-					ProcessType:         "server",
-					AVSRegistrarAddress: "0xdef",
-					DeploymentMode:      DeploymentModeKubernetes,
+					AvsAddress:     "0xabc",
+					ProcessType:    "server",
+					DeploymentMode: DeploymentModeKubernetes,
 					Image: &PerformerImage{
 						Repository: "test/image2",
 						Tag:        "v1.0.0",

--- a/ponos/pkg/executor/executor_test.go
+++ b/ponos/pkg/executor/executor_test.go
@@ -84,7 +84,6 @@ func testWithKeyType(
 		PrivateKey: chainConfig.OperatorAccountPrivateKey,
 	}
 	simAggConfig.Operator.Address = chainConfig.OperatorAccountAddress
-	simAggConfig.Avss[0].AVSRegistrarAddress = chainConfig.AVSTaskRegistrarAddress
 	simAggConfig.Avss[0].Address = chainConfig.AVSAccountAddress
 
 	aggBn254PrivateSigningKey, _, aggGenericExecutorSigningKey, err := testUtils.ParseKeysFromConfig(simAggConfig.Operator, config.CurveTypeBN254)
@@ -139,9 +138,7 @@ func testWithKeyType(
 		t.Fatalf("Failed to create L1 private key ecdsaSigner: %v", err)
 	}
 
-	l1CC, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress, // technically not used...
-	}, l1EthClient, l1PrivateKeySigner, l)
+	l1CC, err := caller.NewContractCaller(l1EthClient, l1PrivateKeySigner, l)
 	if err != nil {
 		t.Fatalf("Failed to create L2 contract caller: %v", err)
 	}

--- a/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
+++ b/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
@@ -125,9 +125,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 				t.Fatalf("Failed to create AVS private key signer: %v", err)
 			}
 
-			avsCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-				AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-			}, ethClient, avsPrivateKeySigner, l)
+			avsCc, err := caller.NewContractCaller(ethClient, avsPrivateKeySigner, l)
 			if err != nil {
 				t.Fatalf("failed to create contract caller: %v", err)
 			}
@@ -137,9 +135,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 				t.Fatalf("Failed to create operator private key signer: %v", err)
 			}
 
-			operatorCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-				AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-			}, ethClient, operatorPrivateKeySigner, l)
+			operatorCc, err := caller.NewContractCaller(ethClient, operatorPrivateKeySigner, l)
 			if err != nil {
 				t.Fatalf("Failed to create contract caller: %v", err)
 			}
@@ -337,9 +333,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 				t.Fatalf("Failed to create AVS private key signer: %v", err)
 			}
 
-			avsCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-				AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-			}, ethClient, avsPrivateKeySigner, l)
+			avsCc, err := caller.NewContractCaller(ethClient, avsPrivateKeySigner, l)
 			if err != nil {
 				t.Fatalf("failed to create contract caller: %v", err)
 			}
@@ -349,9 +343,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 				t.Fatalf("Failed to create operator private key signer: %v", err)
 			}
 
-			operatorCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-				AVSRegistrarAddress: chainConfig.AVSTaskRegistrarAddress,
-			}, ethClient, operatorPrivateKeySigner, l)
+			operatorCc, err := caller.NewContractCaller(ethClient, operatorPrivateKeySigner, l)
 			if err != nil {
 				t.Fatalf("Failed to create contract caller: %v", err)
 			}

--- a/ponos/scratch/hack.go
+++ b/ponos/scratch/hack.go
@@ -47,9 +47,7 @@ func main() {
 		return
 	}
 
-	aggregatorCc, err := caller.NewContractCaller(&caller.ContractCallerConfig{
-		AVSRegistrarAddress: "0x5897a9b8b746c78e0cae876962796949832e3357",
-	}, ethClient, privateKeySigner, l)
+	aggregatorCc, err := caller.NewContractCaller(ethClient, privateKeySigner, l)
 	if err != nil {
 		l.Sugar().Fatalf("failed to create aggregator contract caller: %v", err)
 		return

--- a/ponos/test-aggregator.yaml
+++ b/ponos/test-aggregator.yaml
@@ -53,6 +53,5 @@ chains:
 
 avss:
   - address: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
-    avsRegistrarAddress: "0xf4c5c29b14f0237131f7510a51684c8191f98e06"
     responseTimeout: 3000
     chainIds: [1]

--- a/ponos/test-executor.yaml
+++ b/ponos/test-executor.yaml
@@ -47,6 +47,4 @@ avsPerformers:
 - image:
     repository: "hello-performer"
     tag: "latest"
-  processType: "server"
   avsAddress: "0x70997970c51812dc3a010c7d01b50e0d17dc79c8"
-  avsRegistrarAddress: "0xf4c5c29b14f0237131f7510a51684c8191f98e06"


### PR DESCRIPTION
## Overview
This change removes the requirement of providing an AVS's registrar address during startup of the aggregator or executor. This is avoided by calling the allocation manager for it. This removes the requirement of the AvsPerformer definition entirely from the ExecutorConfig during startup and deploying net-new AVSs to the Executor during runtime. 