### PR TITLE
fix: adding task id validation to task result

### DIFF
--- a/ponos/pkg/signing/aggregation/aggregation_test.go
+++ b/ponos/pkg/signing/aggregation/aggregation_test.go
@@ -181,6 +181,7 @@ func Test_Aggregation(t *testing.T) {
 			operator := operators[i]
 			// Create task result
 			taskResult := &types.TaskResult{
+				TaskId:          taskId,
 				OperatorAddress: operator.Address,
 				Output:          commonPayload,
 				OutputDigest:    digest[:],

--- a/ponos/pkg/signing/aggregation/ecdsa.go
+++ b/ponos/pkg/signing/aggregation/ecdsa.go
@@ -154,6 +154,10 @@ func (tra *ECDSATaskResultAggregator) ProcessNewSignature(
 	taskId string,
 	taskResponse *types.TaskResult,
 ) error {
+	if taskId != taskResponse.TaskId {
+		return fmt.Errorf("task ID mismatch: expected %s, got %s", taskId, taskResponse.TaskId)
+	}
+
 	tra.mu.Lock()
 	defer tra.mu.Unlock()
 

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -266,7 +266,7 @@ func (ts *TaskSession[SigT, CertT, PubKeyT]) Broadcast() (*CertT, error) {
 			)
 			continue
 		}
-		if err := ts.taskAggregator.ProcessNewSignature(ts.context, taskResult.TaskId, taskResult); err != nil {
+		if err := ts.taskAggregator.ProcessNewSignature(ts.context, ts.Task.TaskId, taskResult); err != nil {
 			ts.logger.Sugar().Errorw("Failed to process task result",
 				zap.String("taskId", taskResult.TaskId),
 				zap.String("operatorAddress", taskResult.OperatorAddress),


### PR DESCRIPTION
Description:
The aggregator lacks validation to ensure that the task ID in the submitted task result matches
the expected task ID for the current task session. This allows malicious operators to submit
results with different task IDs, potentially causing signature verification failure or, task result
corruption and gas waste due to failed transactions.

Recommendations: Ensure operators can only contribute results for the specific task they
were assigned, maintaining proper task isolation.