### PR TITLE
fix: task id confusion task session

### DIFF
--- a/ponos/pkg/signing/aggregation/bn254.go
+++ b/ponos/pkg/signing/aggregation/bn254.go
@@ -162,6 +162,11 @@ func (tra *BN254TaskResultAggregator) ProcessNewSignature(
 	tra.mu.Lock()
 	defer tra.mu.Unlock()
 
+	// Validate task ID matches
+	if taskId != taskResponse.TaskId {
+		return fmt.Errorf("task ID mismatch: expected %s, got %s", taskId, taskResponse.TaskId)
+	}
+
 	// Validate operator is in the allowed set
 	operator := util.Find(tra.Operators, func(op *Operator[signing.PublicKey]) bool {
 		return strings.EqualFold(op.Address, taskResponse.OperatorAddress)

--- a/ponos/pkg/signing/aggregation/ecdsa.go
+++ b/ponos/pkg/signing/aggregation/ecdsa.go
@@ -170,6 +170,11 @@ func (tra *ECDSATaskResultAggregator) ProcessNewSignature(
 	tra.mu.Lock()
 	defer tra.mu.Unlock()
 
+	// Validate task ID matches
+	if taskId != taskResponse.TaskId {
+		return fmt.Errorf("task ID mismatch: expected %s, got %s", taskId, taskResponse.TaskId)
+	}
+
 	// Validate operator is in the allowed set
 	operator := util.Find(tra.Operators, func(op *Operator[common.Address]) bool {
 		return strings.EqualFold(op.Address, taskResponse.OperatorAddress)

--- a/ponos/pkg/signing/aggregation/ecdsa.go
+++ b/ponos/pkg/signing/aggregation/ecdsa.go
@@ -167,10 +167,6 @@ func (tra *ECDSATaskResultAggregator) ProcessNewSignature(
 	taskId string,
 	taskResponse *types.TaskResult,
 ) error {
-	if taskId != taskResponse.TaskId {
-		return fmt.Errorf("task ID mismatch: expected %s, got %s", taskId, taskResponse.TaskId)
-	}
-
 	tra.mu.Lock()
 	defer tra.mu.Unlock()
 

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -266,6 +266,13 @@ func (ts *TaskSession[SigT, CertT, PubKeyT]) Broadcast() (*CertT, error) {
 			)
 			continue
 		}
+		if ts.Task.TaskId != taskResult.TaskId {
+			ts.logger.Sugar().Errorw("task ID mismatch: expected",
+				zap.String("expected", ts.Task.TaskId),
+				zap.String("received", taskResult.TaskId),
+			)
+			continue
+		}
 		if err := ts.taskAggregator.ProcessNewSignature(ts.context, ts.Task.TaskId, taskResult); err != nil {
 			ts.logger.Sugar().Errorw("Failed to process task result",
 				zap.String("taskId", taskResult.TaskId),


### PR DESCRIPTION
Adding task id validation in multiple places to ensure we're enforcing this at multiple layers and consistently.