### PR TITLE
fix: fixing the aggregator avs registration flow and adding logging

### DIFF
--- a/ponos/pkg/aggregator/aggregatorConfig/aggregatorConfig.go
+++ b/ponos/pkg/aggregator/aggregatorConfig/aggregatorConfig.go
@@ -2,6 +2,7 @@ package aggregatorConfig
 
 import (
 	"encoding/json"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/auth"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/config"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/util"
 	"github.com/pkg/errors"
@@ -126,6 +127,9 @@ type AggregatorConfig struct {
 
 	// Storage configuration for persistence
 	Storage *StorageConfig `json:"storage,omitempty" yaml:"storage,omitempty"`
+
+	// Authentication configuration for mgmt apis
+	Authentication auth.Config `json:"authentication,omitempty" yaml:"authentication,omitempty"`
 }
 
 func (arc *AggregatorConfig) Validate() error {


### PR DESCRIPTION
### Bug Summary
We were incorrectly checking the config for existing AVS entries when registering an AVS with the Aggregator. We instead need to check that the chain ids exist and simply start polling for them.

### Testing
Validated using `hgctl` :
```
brandonchatham@Brandons-MacBook-Pro hgctl-go % ./bin/hgctl deploy aggregator
[10:37:28]	INFO	Found existing running aggregator container	{"container": "hgctl-aggregator-demo-0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "containerID": "f183a5f50e47"}
[10:37:28]	INFO	Registering AVS with aggregator	{"avsAddress": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "chainIDs": [31337, 31338]}
[10:37:48]	INFO	Successfully registered AVS with aggregator
[10:37:48]	INFO	Successfully registered AVS with existing aggregator
```

