### PR TITLE
fix: operator set validation prior to task execution

### DIFF
--- a/ponos/pkg/executor/handlers.go
+++ b/ponos/pkg/executor/handlers.go
@@ -319,7 +319,7 @@ func (e *Executor) handleReceivedTask(ctx context.Context, task *executorV1.Task
 	if err != nil {
 		return nil, err
 	}
-	if opSet == nil || opSet.OperatorSetID == 0 {
+	if opSet == nil {
 		return nil, fmt.Errorf("invalid task operator set")
 	}
 

--- a/ponos/pkg/executor/handlers.go
+++ b/ponos/pkg/executor/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"strings"
 	"time"
 
@@ -310,6 +311,18 @@ func (e *Executor) handleReceivedTask(ctx context.Context, task *executorV1.Task
 		"taskId", task.TaskId,
 		"avsAddress", task.AvsAddress,
 	)
+	opSet, err := e.l1ContractCaller.GetOperatorSetDetailsForOperator(
+		common.HexToAddress(e.config.Operator.Address),
+		task.GetAvsAddress(),
+		task.OperatorSetId,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if opSet == nil || opSet.OperatorSetID == 0 {
+		return nil, fmt.Errorf("invalid task operator set")
+	}
+
 	avsAddress := strings.ToLower(task.GetAvsAddress())
 	if avsAddress == "" {
 		return nil, fmt.Errorf("AVS address is empty")

--- a/ponos/pkg/executor/handlers.go
+++ b/ponos/pkg/executor/handlers.go
@@ -328,7 +328,7 @@ func (e *Executor) handleReceivedTask(ctx context.Context, task *executorV1.Task
 		return nil, fmt.Errorf("AVS address is empty")
 	}
 
-	value, ok := e.avsPerformers.Load(task.AvsAddress)
+	value, ok := e.avsPerformers.Load(avsAddress)
 
 	if !ok {
 		return nil, fmt.Errorf("AVS avsPerf not found for address %s", avsAddress)

--- a/ponos/pkg/executor/handlers_test.go
+++ b/ponos/pkg/executor/handlers_test.go
@@ -209,7 +209,7 @@ func TestHandleReceivedTask_OperatorValidation(t *testing.T) {
 				config:           execConfig,
 				l1ContractCaller: mockCaller,
 				logger:           l,
-				avsPerformers:    make(map[string]avsPerformer.IAvsPerformer),
+				avsPerformers:    &sync.Map{},
 				store:            memory.NewInMemoryExecutorStore(),
 				inflightTasks:    &sync.Map{},
 				ecdsaSigner:      &MockSigner{},
@@ -218,7 +218,7 @@ func TestHandleReceivedTask_OperatorValidation(t *testing.T) {
 
 			// Store performer with normalized (lowercase) address to match production behavior
 			if tt.task.AvsAddress != "" {
-				e.avsPerformers[strings.ToLower(tt.task.AvsAddress)] = &MockPerformer{}
+				e.avsPerformers.Store(strings.ToLower(tt.task.AvsAddress), &MockPerformer{})
 			}
 
 			result, err := e.handleReceivedTask(context.Background(), tt.task)


### PR DESCRIPTION
## Vulnerability
The executor only validates that it supports a given AVS but does not verify that it is a member of the specific operator set for the task, allowing operators to execute and sign tasks for operator sets they do not belong to.
When receiving task submissions, the executor performs only a basic AVS validation but ignores the operator set membership requirement.

## Fix
Verify the operator is in the operator-set of the task before execution. 