### PR TITLE
fix: verify executor identity and bind results to authentic signatures

### DIFF
--- a/ponos/gen/protos/eigenlayer/hourglass/v1/executor/executor.pb.go
+++ b/ponos/gen/protos/eigenlayer/hourglass/v1/executor/executor.pb.go
@@ -32,6 +32,7 @@ type TaskSubmission struct {
 	Signature          []byte                 `protobuf:"bytes,5,opt,name=signature,proto3" json:"signature,omitempty"`
 	OperatorSetId      uint32                 `protobuf:"varint,6,opt,name=operator_set_id,json=operatorSetId,proto3" json:"operator_set_id,omitempty"`
 	ReferenceTimestamp uint32                 `protobuf:"varint,7,opt,name=reference_timestamp,json=referenceTimestamp,proto3" json:"reference_timestamp,omitempty"`
+	ExecutorAddress    string                 `protobuf:"bytes,8,opt,name=executor_address,json=executorAddress,proto3" json:"executor_address,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -115,15 +116,22 @@ func (x *TaskSubmission) GetReferenceTimestamp() uint32 {
 	return 0
 }
 
+func (x *TaskSubmission) GetExecutorAddress() string {
+	if x != nil {
+		return x.ExecutorAddress
+	}
+	return ""
+}
+
 type TaskResult struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	TaskId          string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
 	OperatorAddress string                 `protobuf:"bytes,2,opt,name=operator_address,json=operatorAddress,proto3" json:"operator_address,omitempty"`
 	Output          []byte                 `protobuf:"bytes,3,opt,name=output,proto3" json:"output,omitempty"`
-	Signature       []byte                 `protobuf:"bytes,4,opt,name=signature,proto3" json:"signature,omitempty"`
+	ResultSignature []byte                 `protobuf:"bytes,4,opt,name=result_signature,json=resultSignature,proto3" json:"result_signature,omitempty"` // Signs hash(output) - for aggregation
 	AvsAddress      string                 `protobuf:"bytes,5,opt,name=avs_address,json=avsAddress,proto3" json:"avs_address,omitempty"`
 	OperatorSetId   uint32                 `protobuf:"varint,6,opt,name=operator_set_id,json=operatorSetId,proto3" json:"operator_set_id,omitempty"`
-	OutputDigest    []byte                 `protobuf:"bytes,7,opt,name=output_digest,json=outputDigest,proto3" json:"output_digest,omitempty"`
+	AuthSignature   []byte                 `protobuf:"bytes,7,opt,name=auth_signature,json=authSignature,proto3" json:"auth_signature,omitempty"` // Signs identity data - for authentication
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -179,9 +187,9 @@ func (x *TaskResult) GetOutput() []byte {
 	return nil
 }
 
-func (x *TaskResult) GetSignature() []byte {
+func (x *TaskResult) GetResultSignature() []byte {
 	if x != nil {
-		return x.Signature
+		return x.ResultSignature
 	}
 	return nil
 }
@@ -200,9 +208,9 @@ func (x *TaskResult) GetOperatorSetId() uint32 {
 	return 0
 }
 
-func (x *TaskResult) GetOutputDigest() []byte {
+func (x *TaskResult) GetAuthSignature() []byte {
 	if x != nil {
-		return x.OutputDigest
+		return x.AuthSignature
 	}
 	return nil
 }
@@ -1093,7 +1101,7 @@ var File_eigenlayer_hourglass_v1_executor_executor_proto protoreflect.FileDescri
 
 const file_eigenlayer_hourglass_v1_executor_executor_proto_rawDesc = "" +
 	"\n" +
-	"/eigenlayer/hourglass/v1/executor/executor.proto\x12\x17eigenlayer.hourglass.v1\x1a)eigenlayer/hourglass/v1/common/auth.proto\"\x8a\x02\n" +
+	"/eigenlayer/hourglass/v1/executor/executor.proto\x12\x17eigenlayer.hourglass.v1\x1a)eigenlayer/hourglass/v1/common/auth.proto\"\xb5\x02\n" +
 	"\x0eTaskSubmission\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12-\n" +
 	"\x12aggregator_address\x18\x02 \x01(\tR\x11aggregatorAddress\x12\x1f\n" +
@@ -1102,17 +1110,18 @@ const file_eigenlayer_hourglass_v1_executor_executor_proto_rawDesc = "" +
 	"\apayload\x18\x04 \x01(\fR\apayload\x12\x1c\n" +
 	"\tsignature\x18\x05 \x01(\fR\tsignature\x12&\n" +
 	"\x0foperator_set_id\x18\x06 \x01(\rR\roperatorSetId\x12/\n" +
-	"\x13reference_timestamp\x18\a \x01(\rR\x12referenceTimestamp\"\xf4\x01\n" +
+	"\x13reference_timestamp\x18\a \x01(\rR\x12referenceTimestamp\x12)\n" +
+	"\x10executor_address\x18\b \x01(\tR\x0fexecutorAddress\"\x83\x02\n" +
 	"\n" +
 	"TaskResult\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12)\n" +
 	"\x10operator_address\x18\x02 \x01(\tR\x0foperatorAddress\x12\x16\n" +
-	"\x06output\x18\x03 \x01(\fR\x06output\x12\x1c\n" +
-	"\tsignature\x18\x04 \x01(\fR\tsignature\x12\x1f\n" +
+	"\x06output\x18\x03 \x01(\fR\x06output\x12)\n" +
+	"\x10result_signature\x18\x04 \x01(\fR\x0fresultSignature\x12\x1f\n" +
 	"\vavs_address\x18\x05 \x01(\tR\n" +
 	"avsAddress\x12&\n" +
-	"\x0foperator_set_id\x18\x06 \x01(\rR\roperatorSetId\x12#\n" +
-	"\routput_digest\x18\a \x01(\fR\foutputDigest\"D\n" +
+	"\x0foperator_set_id\x18\x06 \x01(\rR\roperatorSetId\x12%\n" +
+	"\x0eauth_signature\x18\a \x01(\fR\rauthSignature\"D\n" +
 	"\x10KubernetesConfig\x120\n" +
 	"\x14service_account_name\x18\x01 \x01(\tR\x12serviceAccountName\"\xba\x02\n" +
 	"\x15DeployArtifactRequest\x12\x1f\n" +

--- a/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
+++ b/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
@@ -334,8 +334,7 @@ func Test_CertificateVerifier(t *testing.T) {
 		OperatorSetId:   taskOpsetId,
 		Output:          []byte("test-task-output-data"),
 		OperatorAddress: chainConfig.ExecOperatorAccountAddress,
-		Signature:       nil,
-		OutputDigest:    nil,
+		ResultSignature: nil,
 	}
 	messageHash := util.GetKeccak256Digest(taskResult.Output)
 	// Sign the result
@@ -414,8 +413,7 @@ func Test_CertificateVerifier(t *testing.T) {
 
 	// Use InMemorySigner signature for the test to ensure it passes
 	// while still testing that Web3Signer produces a signature
-	taskResult.Signature = inMemSig // Use InMemory signature instead of Web3Signer
-	taskResult.OutputDigest = ecdsaDigest[:]
+	taskResult.ResultSignature = inMemSig // Use InMemory signature instead of Web3Signer
 
 	t.Logf("Using InMemorySigner signature for aggregation test to verify the process works")
 

--- a/ponos/pkg/aggregator/avsExecutionManager/avsExecutionManager.go
+++ b/ponos/pkg/aggregator/avsExecutionManager/avsExecutionManager.go
@@ -537,11 +537,6 @@ func (em *AvsExecutionManager) handleTask(ctx context.Context, task *types.Task)
 		return fmt.Errorf("unsupported curve type: %s", avsConfig.curveType)
 	}
 
-	sig, err := signerToUse.SignMessage(task.Payload)
-	if err != nil {
-		return fmt.Errorf("failed to sign task payload: %w", err)
-	}
-
 	chainCC, err := em.getContractCallerForChain(task.ChainId)
 	if err != nil {
 		em.logger.Sugar().Errorw("Failed to get contract caller for chain",
@@ -583,7 +578,7 @@ func (em *AvsExecutionManager) handleTask(ctx context.Context, task *types.Task)
 			cancel,
 			task,
 			em.config.AggregatorAddress,
-			sig,
+			signerToUse,
 			operatorPeersWeight,
 			em.config.InsecureExecutorConnections,
 			em.logger,
@@ -602,7 +597,7 @@ func (em *AvsExecutionManager) handleTask(ctx context.Context, task *types.Task)
 			cancel,
 			task,
 			em.config.AggregatorAddress,
-			sig,
+			signerToUse,
 			operatorPeersWeight,
 			em.config.InsecureExecutorConnections,
 			em.logger,

--- a/ponos/pkg/executor/auth_integration_test.go
+++ b/ponos/pkg/executor/auth_integration_test.go
@@ -32,9 +32,7 @@ import (
 
 // TestAuthenticationWithRealExecutor tests authentication using a real executor setup
 func TestAuthenticationWithRealExecutor(t *testing.T) {
-	t.Skip("Skipping integration test - requires Anvil and Docker")
-
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(120*time.Second))
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(180*time.Second))
 	defer cancel()
 
 	// Setup logger
@@ -58,6 +56,11 @@ func TestAuthenticationWithRealExecutor(t *testing.T) {
 	execConfig.Operator.Address = chainConfig.ExecOperatorAccountAddress
 	if len(execConfig.AvsPerformers) > 0 {
 		execConfig.AvsPerformers[0].AvsAddress = chainConfig.AVSAccountAddress
+	}
+
+	// Enable authentication for testing
+	execConfig.AuthConfig = &auth.Config{
+		IsEnabled: true,
 	}
 
 	// Parse keys for executor
@@ -268,13 +271,12 @@ func TestAuthenticationWithRealExecutor(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		resp, err := authClient.RemovePerformer(ctx, &executorV1.RemovePerformerRequest{
+		_, err = authClient.RemovePerformer(ctx, &executorV1.RemovePerformerRequest{
 			PerformerId: "non-existent",
 		})
 
 		// Will fail with NotFound, but auth should pass
 		assert.Error(t, err)
-		assert.NotNil(t, resp)
 		statusErr, ok := status.FromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, codes.NotFound, statusErr.Code())

--- a/ponos/pkg/executor/avsPerformer/avsContainerPerformer/server_integration_test.go
+++ b/ponos/pkg/executor/avsPerformer/avsContainerPerformer/server_integration_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/containerManager"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/executor/avsPerformer"
-	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/peering/localPeeringDataFetcher"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/performerTask"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,11 +51,6 @@ func TestPerformerDrainingIntegration(t *testing.T) {
 	baseContainerMgr, err := containerManager.NewDockerContainerManager(containerManager.DefaultContainerManagerConfig(), logger)
 	require.NoError(t, err)
 
-	// Create peering data fetcher
-	pdf := localPeeringDataFetcher.NewLocalPeeringDataFetcher(&localPeeringDataFetcher.LocalPeeringDataFetcherConfig{
-		AggregatorPeers: nil,
-	}, logger)
-
 	t.Run("draining during promotion and routing to new performer", func(t *testing.T) {
 		// Create performer config
 		performerConfig := &avsPerformer.AvsPerformerConfig{
@@ -75,7 +69,6 @@ func TestPerformerDrainingIntegration(t *testing.T) {
 		// Create serverPerformer with wrapped container manager
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			containerMgr,
 		)
@@ -170,7 +163,6 @@ func TestPerformerDrainingIntegration(t *testing.T) {
 		// Create serverPerformer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			baseContainerMgr,
 		)
@@ -218,11 +210,6 @@ func TestDeploymentIntegration(t *testing.T) {
 	containerMgr, err := containerManager.NewDockerContainerManager(containerManager.DefaultContainerManagerConfig(), logger)
 	require.NoError(t, err)
 
-	// Create peering data fetcher
-	pdf := localPeeringDataFetcher.NewLocalPeeringDataFetcher(&localPeeringDataFetcher.LocalPeeringDataFetcherConfig{
-		AggregatorPeers: nil,
-	}, logger)
-
 	t.Run("successful deployment with real container", func(t *testing.T) {
 		// Create performer config
 		performerConfig := &avsPerformer.AvsPerformerConfig{
@@ -235,7 +222,6 @@ func TestDeploymentIntegration(t *testing.T) {
 		// Create container performer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			containerMgr,
 		)
@@ -287,7 +273,6 @@ func TestDeploymentIntegration(t *testing.T) {
 		// Create container performer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			slowContainerMgr,
 		)
@@ -329,7 +314,6 @@ func TestDeploymentIntegration(t *testing.T) {
 		// Create container performer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			containerMgr,
 		)
@@ -383,7 +367,6 @@ func TestDeploymentIntegration(t *testing.T) {
 		// Create container performer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			containerMgr,
 		)
@@ -465,11 +448,6 @@ func TestListPerformersIntegration(t *testing.T) {
 	containerMgr, err := containerManager.NewDockerContainerManager(containerManager.DefaultContainerManagerConfig(), logger)
 	require.NoError(t, err)
 
-	// Create peering data fetcher
-	pdf := localPeeringDataFetcher.NewLocalPeeringDataFetcher(&localPeeringDataFetcher.LocalPeeringDataFetcherConfig{
-		AggregatorPeers: nil,
-	}, logger)
-
 	t.Run("list performers empty state", func(t *testing.T) {
 		// Create performer config
 		performerConfig := &avsPerformer.AvsPerformerConfig{
@@ -482,7 +460,6 @@ func TestListPerformersIntegration(t *testing.T) {
 		// Create container performer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			containerMgr,
 		)
@@ -511,7 +488,6 @@ func TestListPerformersIntegration(t *testing.T) {
 		// Create container performer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			containerMgr,
 		)
@@ -562,7 +538,6 @@ func TestListPerformersIntegration(t *testing.T) {
 		// Create container performer
 		server := NewAvsContainerPerformerWithContainerManager(
 			performerConfig,
-			pdf,
 			logger,
 			containerMgr,
 		)

--- a/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/connection_integration_test.go
+++ b/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/connection_integration_test.go
@@ -31,7 +31,7 @@ func TestAvsKubernetesPerformer_ConnectionRetryIntegration(t *testing.T) {
 		KubeconfigPath:    "", // Fixed field name
 	}
 
-	akp, err := NewAvsKubernetesPerformer(config, kubernetesConfig, nil, nil, logger)
+	akp, err := NewAvsKubernetesPerformer(config, kubernetesConfig, logger)
 	if err != nil {
 		// Expected error in test environment without k8s
 		t.Logf("Expected error creating performer without valid k8s config: %v", err)

--- a/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/e2e_integration_test.go
+++ b/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/e2e_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/executor/avsPerformer"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/kubernetesManager"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/logger"
-	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/peering/localPeeringDataFetcher"
 	"go.uber.org/zap"
 )
 
@@ -91,11 +90,6 @@ func TestE2E_KubernetesPerformer_FullWorkflow(t *testing.T) {
 
 	t.Logf("Operator deployed successfully: %s", operator.ReleaseName)
 
-	// Create peering data fetcher
-	pdf := localPeeringDataFetcher.NewLocalPeeringDataFetcher(&localPeeringDataFetcher.LocalPeeringDataFetcherConfig{
-		AggregatorPeers: nil,
-	}, l)
-
 	// Create AvsKubernetesPerformer without image (so Initialize doesn't hang)
 	performerConfig := &avsPerformer.AvsPerformerConfig{
 		AvsAddress: "0xtest-avs-address",
@@ -116,8 +110,6 @@ func TestE2E_KubernetesPerformer_FullWorkflow(t *testing.T) {
 	performer, err := NewAvsKubernetesPerformer(
 		performerConfig,
 		kubernetesConfig,
-		pdf,
-		nil,
 		l,
 	)
 	if err != nil {

--- a/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/kubernetesPerformer_test.go
+++ b/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/kubernetesPerformer_test.go
@@ -123,7 +123,6 @@ func createTestKubernetesPerformer(t *testing.T) (*AvsKubernetesPerformer, *Mock
 		config:              config,
 		kubernetesConfig:    kubernetesConfig,
 		logger:              logger,
-		peeringFetcher:      mockPeeringFetcher,
 		performerTaskStates: make(map[string]*PerformerTaskState),
 	}
 
@@ -146,7 +145,7 @@ func TestNewAvsKubernetesPerformer(t *testing.T) {
 	logger := zaptest.NewLogger(t)
 
 	// Create performer - it may or may not fail depending on the test environment
-	performer, err := NewAvsKubernetesPerformer(config, kubernetesConfig, nil, nil, logger)
+	performer, err := NewAvsKubernetesPerformer(config, kubernetesConfig, logger)
 
 	// In most test environments without a real k8s cluster, this will fail
 	// In environments with kind or a real cluster, it might succeed

--- a/ponos/pkg/executor/avsPerformer/avsPerformer.go
+++ b/ponos/pkg/executor/avsPerformer/avsPerformer.go
@@ -112,7 +112,6 @@ type PerformerCreationResult struct {
 type IAvsPerformer interface {
 	Initialize(ctx context.Context) error
 	RunTask(ctx context.Context, task *performerTask.PerformerTask) (*performerTask.PerformerTaskResult, error)
-	ValidateTaskSignature(task *performerTask.PerformerTask) error
 	Deploy(ctx context.Context, image PerformerImage) (*DeploymentResult, error)
 	CreatePerformer(ctx context.Context, image PerformerImage) (*PerformerCreationResult, error)
 	PromotePerformer(ctx context.Context, performerID string) error

--- a/ponos/pkg/executor/executor.go
+++ b/ponos/pkg/executor/executor.go
@@ -21,6 +21,8 @@ import (
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/rpcServer"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/signer"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Executor struct {
@@ -265,8 +267,6 @@ func (e *Executor) createDockerPerformer(avs *executorConfig.AvsPerformerConfig,
 			ProcessType:          avsPerformer.AvsProcessType(avs.ProcessType),
 			PerformerNetworkName: e.config.PerformerNetworkName,
 		},
-		e.peeringFetcher,
-		e.l1ContractCaller,
 		e.logger,
 	)
 }
@@ -299,8 +299,6 @@ func (e *Executor) createKubernetesPerformer(avs *executorConfig.AvsPerformerCon
 			EndpointOverride: endpointOverride,
 		},
 		kubernetesConfig,
-		e.peeringFetcher,
-		e.l1ContractCaller,
 		e.logger,
 	)
 }
@@ -373,10 +371,19 @@ func (e *Executor) registerHandlers() error {
 
 // verifyAuth is a helper method to verify authentication
 func (e *Executor) verifyAuth(auth *commonV1.AuthSignature) error {
-	if e.authVerifier != nil {
-		if err := e.authVerifier.VerifyAuthentication(auth); err != nil {
-			return err
+	// If auth is not enabled, check if auth was provided
+	if e.authVerifier == nil {
+		// If auth was provided but not enabled, return unimplemented
+		if auth != nil {
+			return status.Error(codes.Unimplemented, "authentication is not enabled")
 		}
+		// No auth required and none provided - OK
+		return nil
+	}
+
+	// Auth is enabled, verify it
+	if err := e.authVerifier.VerifyAuthentication(auth); err != nil {
+		return err
 	}
 	return nil
 }

--- a/ponos/pkg/executor/signature_validation_test.go
+++ b/ponos/pkg/executor/signature_validation_test.go
@@ -1,0 +1,1033 @@
+package executor
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/Layr-Labs/crypto-libs/pkg/bn254"
+	ecdsacrypto "github.com/Layr-Labs/crypto-libs/pkg/ecdsa"
+	executorV1 "github.com/Layr-Labs/hourglass-monorepo/ponos/gen/protos/eigenlayer/hourglass/v1/executor"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/config"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/contractCaller"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/executor/avsPerformer"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/executor/executorConfig"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/executor/storage/memory"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/logger"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/peering"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/performerTask"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/signer"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/util"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateTaskSignature_ValidECDSA tests validation of a valid ECDSA signature
+func TestValidateTaskSignature_ValidECDSA(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	aggregatorAddress := crypto.PubkeyToAddress(aggregatorPrivKey.PublicKey).Hex()
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeECDSA)
+
+	// Create signed task
+	task := CreateSignedTaskSubmission(t, aggregatorPrivKey, executorAddress, avsAddress)
+
+	// Create executor
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+	}
+
+	// Test
+	err = e.validateTaskSignature(task)
+
+	// Assert
+	assert.NoError(t, err, "Valid ECDSA signature should pass validation")
+	mockCaller.AssertExpectations(t)
+}
+
+// TestValidateTaskSignature_ValidBN254 tests validation of a valid BN254 signature
+func TestValidateTaskSignature_ValidBN254(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, aggregatorPubKey, err := bn254.GenerateKeyPair()
+	require.NoError(t, err)
+	aggregatorAddress := "0xaggregator00000000000000000000000000000"
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller with manual setup for BN254
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeBN254)
+
+	// Manually set up the BN254 public key
+	key := fmt.Sprintf("%s-%s-%d", aggregatorAddress, avsAddress, 0)
+	mockCaller.operatorSets[key].WrappedPublicKey.PublicKey = aggregatorPubKey
+
+	// Create signed task
+	task := CreateSignedTaskSubmission(t, aggregatorPrivKey, executorAddress, avsAddress)
+	task.AggregatorAddress = aggregatorAddress // Override since BN254 doesn't derive address
+
+	// Create executor
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+	}
+
+	// Test
+	err = e.validateTaskSignature(task)
+
+	// Assert
+	assert.NoError(t, err, "Valid BN254 signature should pass validation")
+	mockCaller.AssertExpectations(t)
+}
+
+// TestValidateTaskSignature_InvalidSignature tests rejection of invalid signatures
+func TestValidateTaskSignature_InvalidSignature(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	aggregatorAddress := crypto.PubkeyToAddress(aggregatorPrivKey.PublicKey).Hex()
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeECDSA)
+
+	// Create task with invalid signature
+	task := CreateValidTaskSubmission(t, aggregatorPrivKey, executorAddress, avsAddress)
+	task.Signature = []byte("invalid signature data that is long enough but wrong")
+
+	// Create executor
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+	}
+
+	// Test
+	err = e.validateTaskSignature(task)
+
+	// Assert
+	assert.Error(t, err, "Invalid signature should fail validation")
+	assert.Contains(t, err.Error(), "signature", "Error should mention signature")
+}
+
+// TestValidateTaskSignature_WrongExecutor tests rejection when signature is for different executor
+func TestValidateTaskSignature_WrongExecutor(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	aggregatorAddress := crypto.PubkeyToAddress(aggregatorPrivKey.PublicKey).Hex()
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	wrongExecutorAddress := "0x9999999999999999999999999999999999999999"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeECDSA)
+
+	// Create task signed for wrong executor
+	task := CreateSignedTaskSubmission(t, aggregatorPrivKey, wrongExecutorAddress, avsAddress)
+
+	// Create executor with different address
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress, // Different from what was signed
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+	}
+
+	// Test
+	err = e.validateTaskSignature(task)
+
+	// Assert
+	assert.Error(t, err, "Signature for wrong executor should fail validation")
+	assert.Contains(t, err.Error(), "signature verification failed", "Error should mention signature verification")
+}
+
+// TestValidateTaskSignature_TamperedPayload tests rejection when payload is tampered
+func TestValidateTaskSignature_TamperedPayload(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	aggregatorAddress := crypto.PubkeyToAddress(aggregatorPrivKey.PublicKey).Hex()
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeECDSA)
+
+	// Create signed task then tamper with payload
+	task := CreateSignedTaskSubmission(t, aggregatorPrivKey, executorAddress, avsAddress)
+	task.Payload = []byte("tampered payload data")
+
+	// Create executor
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+	}
+
+	// Test
+	err = e.validateTaskSignature(task)
+
+	// Assert
+	assert.Error(t, err, "Tampered payload should fail validation")
+	assert.Contains(t, err.Error(), "signature verification failed", "Error should mention signature verification")
+}
+
+// TestValidateTaskSignature_WrongAggregator tests rejection when signed by non-aggregator
+func TestValidateTaskSignature_WrongAggregator(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	aggregatorAddress := crypto.PubkeyToAddress(aggregatorPrivKey.PublicKey).Hex()
+
+	wrongPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller - setup with correct aggregator
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeECDSA)
+
+	// Create task signed by wrong key
+	task := CreateSignedTaskSubmission(t, wrongPrivKey, executorAddress, avsAddress)
+	task.AggregatorAddress = aggregatorAddress // Claim to be the aggregator
+
+	// Create executor
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+	}
+
+	// Test
+	err = e.validateTaskSignature(task)
+
+	// Assert
+	assert.Error(t, err, "Signature from wrong aggregator should fail validation")
+	assert.Contains(t, err.Error(), "signature verification failed", "Error should mention signature verification")
+}
+
+// TestValidateTaskSignature_MissingAVSConfig tests handling of missing AVS config
+func TestValidateTaskSignature_MissingAVSConfig(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller that returns error for AVS config
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.On("GetAVSConfig", avsAddress).Return(nil, assert.AnError)
+
+	// Create signed task
+	task := CreateSignedTaskSubmission(t, aggregatorPrivKey, executorAddress, avsAddress)
+
+	// Create executor
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+	}
+
+	// Test
+	err = e.validateTaskSignature(task)
+
+	// Assert
+	assert.Error(t, err, "Missing AVS config should fail validation")
+	assert.Contains(t, err.Error(), "AVS config", "Error should mention AVS config")
+	mockCaller.AssertExpectations(t)
+}
+
+// TestHandleReceivedTask_ValidTaskAccepted tests that valid tasks are accepted and passed to performer
+func TestHandleReceivedTask_ValidTaskAccepted(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	aggregatorAddress := crypto.PubkeyToAddress(aggregatorPrivKey.PublicKey).Hex()
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeECDSA)
+	mockCaller.SetupValidOperatorSet(executorAddress, avsAddress, 1)
+	mockCaller.SetupOperatorSetCurveType(avsAddress, 1, config.CurveTypeECDSA)
+
+	// Setup certificate digest calculation
+	mockCaller.On("CalculateECDSACertificateDigestBytes", mock.Anything, mock.AnythingOfType("uint32"), mock.AnythingOfType("[32]uint8")).
+		Return([]byte("certificate_digest"), nil)
+
+	// Create mock performer
+	mockPerformer := NewConfigurableMockPerformer()
+	mockPerformer.SetCustomResponse([]byte("task completed successfully"))
+
+	// Create signed task
+	task := CreateSignedTaskSubmission(t, aggregatorPrivKey, executorAddress, avsAddress)
+
+	// Create executor with signers
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	executorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		avsPerformers:    &sync.Map{},
+		store:            memory.NewInMemoryExecutorStore(),
+		inflightTasks:    &sync.Map{},
+		ecdsaSigner:      NewECDSATestSigner(executorPrivKey),
+	}
+
+	// Store performer
+	e.avsPerformers.Store(avsAddress, mockPerformer)
+
+	// Test
+	result, err := e.handleReceivedTask(context.Background(), task)
+
+	// Assert
+	assert.NoError(t, err, "Valid task should be accepted")
+	assert.NotNil(t, result, "Result should not be nil")
+	assert.Equal(t, task.TaskId, result.TaskId, "Result should have correct task ID")
+	assert.Equal(t, []byte("task completed successfully"), result.Output, "Result should have performer output")
+	mockCaller.AssertExpectations(t)
+}
+
+// TestHandleReceivedTask_InvalidTaskRejected tests that invalid tasks are rejected
+func TestHandleReceivedTask_InvalidTaskRejected(t *testing.T) {
+	// Setup
+	aggregatorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	aggregatorAddress := crypto.PubkeyToAddress(aggregatorPrivKey.PublicKey).Hex()
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	wrongExecutorAddress := "0x9999999999999999999999999999999999999999"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupValidAggregator(avsAddress, aggregatorAddress, config.CurveTypeECDSA)
+	mockCaller.SetupValidOperatorSet(executorAddress, avsAddress, 1)
+
+	// Create mock performer
+	mockPerformer := NewConfigurableMockPerformer()
+
+	// Create task signed for wrong executor (signature won't match)
+	task := CreateSignedTaskSubmission(t, aggregatorPrivKey, wrongExecutorAddress, avsAddress)
+	// Set the executor address to match what the executor expects (to pass initial validation)
+	task.ExecutorAddress = executorAddress
+
+	// Create executor with signers
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	executorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		avsPerformers:    &sync.Map{},
+		store:            memory.NewInMemoryExecutorStore(),
+		inflightTasks:    &sync.Map{},
+		ecdsaSigner:      NewECDSATestSigner(executorPrivKey),
+	}
+
+	// Store performer
+	e.avsPerformers.Store(avsAddress, mockPerformer)
+
+	// Test
+	result, err := e.handleReceivedTask(context.Background(), task)
+
+	// Assert
+	assert.Error(t, err, "Invalid task should be rejected")
+	assert.Nil(t, result, "Result should be nil for rejected task")
+	assert.Contains(t, err.Error(), "signature verification failed", "Error should mention signature verification")
+
+	// Verify performer was never called
+	mockPerformer.AssertNotCalled(t, "RunTask")
+	mockCaller.AssertExpectations(t)
+}
+
+// TestSignResult_ECDSA tests ECDSA signature generation for task results
+func TestSignResult_ECDSA(t *testing.T) {
+	// Setup
+	executorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	executorAddress := crypto.PubkeyToAddress(executorPrivKey.PublicKey).Hex()
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupOperatorSetCurveType(avsAddress, 1, config.CurveTypeECDSA)
+
+	// Setup certificate digest calculation expectation
+	// The mock should return some deterministic bytes when asked to calculate the certificate digest
+	expectedDigestBytes := []byte("mocked_certificate_digest_for_ecdsa")
+	mockCaller.On("CalculateECDSACertificateDigestBytes", mock.Anything, mock.Anything, mock.Anything).Return(expectedDigestBytes, nil).Maybe()
+
+	// Create executor with ECDSA signer
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		ecdsaSigner:      NewECDSATestSigner(executorPrivKey),
+	}
+
+	// Create task and result
+	task := &performerTask.PerformerTask{
+		TaskID:        "0x0000000000000000000000000000000000000000000000000000000000000001",
+		Avs:           avsAddress,
+		OperatorSetId: 1,
+		Payload:       []byte("test payload"),
+	}
+
+	result := &performerTask.PerformerTaskResult{
+		TaskID: task.TaskID,
+		Result: []byte("task output data"),
+	}
+
+	// Test
+	resultSig, authSig, err := e.signResult(task, result)
+
+	// Assert
+	assert.NoError(t, err, "ECDSA signing should succeed")
+	assert.NotEmpty(t, resultSig, "Result signature should not be empty")
+	assert.NotEmpty(t, authSig, "Auth signature should not be empty")
+	// ECDSA signatures are typically 65 bytes (r: 32, s: 32, v: 1)
+	assert.Len(t, resultSig, 65, "Result signature should be 65 bytes for ECDSA")
+	assert.Len(t, authSig, 65, "Auth signature should be 65 bytes for ECDSA")
+
+	mockCaller.AssertExpectations(t)
+}
+
+// TestSignResult_BN254 tests BN254 signature generation for task results
+func TestSignResult_BN254(t *testing.T) {
+	// Setup
+	resultPayload := []byte("test resultPayload")
+	executorPrivKey, _, err := bn254.GenerateKeyPair()
+	require.NoError(t, err)
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupOperatorSetCurveType(avsAddress, 1, config.CurveTypeBN254)
+
+	// Setup certificate digest calculation expectation
+	// The mock should return some deterministic bytes when asked to calculate the certificate digest
+	expectedDigestBytes := []byte("mocked_certificate_digest_for_bn254")
+	mockCaller.On("CalculateBN254CertificateDigestBytes", mock.Anything, mock.Anything, mock.Anything).Return(expectedDigestBytes, nil).Maybe()
+
+	// Create executor with BN254 signer
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		bn254Signer:      NewBN254TestSigner(executorPrivKey),
+	}
+
+	// Create task and result
+	task := &performerTask.PerformerTask{
+		TaskID:        "0x0000000000000000000000000000000000000000000000000000000000000001",
+		Avs:           avsAddress,
+		OperatorSetId: 1,
+		Payload:       []byte("test resultPayload"),
+	}
+
+	result := &performerTask.PerformerTaskResult{
+		TaskID: task.TaskID,
+		Result: resultPayload,
+	}
+
+	// Test
+	resultSig, authSig, err := e.signResult(task, result)
+
+	// Assert
+	assert.NoError(t, err, "BN254 signing should succeed")
+	assert.NotEmpty(t, resultSig, "Result signature should not be empty")
+	assert.NotEmpty(t, authSig, "Auth signature should not be empty")
+	// BN254 signatures are 64 bytes (two field elements of 32 bytes each)
+	assert.Len(t, resultSig, 64, "Result signature should be 64 bytes for BN254")
+	assert.Len(t, authSig, 64, "Auth signature should be 64 bytes for BN254")
+
+	mockCaller.AssertExpectations(t)
+}
+
+// TestSignResult_BindsToExecutor tests that result signatures are bound to specific executor
+func TestSignResult_BindsToExecutor(t *testing.T) {
+	// Setup two different executors
+	executor1PrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	executor1Address := crypto.PubkeyToAddress(executor1PrivKey.PublicKey).Hex()
+
+	executor2PrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	executor2Address := crypto.PubkeyToAddress(executor2PrivKey.PublicKey).Hex()
+
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupOperatorSetCurveType(avsAddress, 1, config.CurveTypeECDSA)
+
+	// Setup certificate digest calculation expectation
+	mockCaller.On("CalculateECDSACertificateDigestBytes", mock.Anything, mock.Anything, mock.Anything).Return([]byte("mocked_certificate_digest"), nil).Maybe()
+
+	// Create logger
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	// Create first executor
+	e1 := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executor1Address,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		ecdsaSigner:      NewECDSATestSigner(executor1PrivKey),
+	}
+
+	// Create second executor
+	e2 := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executor2Address,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		ecdsaSigner:      NewECDSATestSigner(executor2PrivKey),
+	}
+
+	// Create identical task and result for both
+	task := &performerTask.PerformerTask{
+		TaskID:        "0x0000000000000000000000000000000000000000000000000000000000000001",
+		Avs:           avsAddress,
+		OperatorSetId: 1,
+		Payload:       []byte("test payload"),
+	}
+
+	result := &performerTask.PerformerTaskResult{
+		TaskID: task.TaskID,
+		Result: []byte("task output data"),
+	}
+
+	// Sign with both executors
+	resultSig1, authSig1, err := e1.signResult(task, result)
+	require.NoError(t, err)
+
+	resultSig2, authSig2, err := e2.signResult(task, result)
+	require.NoError(t, err)
+
+	// Assert
+	// Result signatures will be different because different private keys are used
+	// But they're signing the same data (certificate digest)
+	assert.NotEqual(t, resultSig1, resultSig2, "Different private keys produce different signatures")
+	// Auth signatures should also be different (different operator addresses + different keys)
+	assert.NotEqual(t, authSig1, authSig2, "Different executors should produce different auth signatures")
+}
+
+// TestSignResult_IncludesAllFields tests that result signatures include all required fields
+func TestSignResult_IncludesAllFields(t *testing.T) {
+	// Setup
+	resultPayload := []byte("complex output with unicode 你好世界 and emojis 🚀")
+	executorPrivKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	executorAddress := crypto.PubkeyToAddress(executorPrivKey.PublicKey).Hex()
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupOperatorSetCurveType(avsAddress, 2, config.CurveTypeECDSA)
+
+	// Setup certificate digest calculation expectation
+	mockCaller.On("CalculateECDSACertificateDigestBytes", mock.Anything, mock.Anything, mock.Anything).Return([]byte("mocked_certificate_digest"), nil).Maybe()
+
+	// Create executor
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		ecdsaSigner:      NewECDSATestSigner(executorPrivKey),
+	}
+
+	// Create task with all fields populated
+	task := &performerTask.PerformerTask{
+		TaskID:        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		Avs:           avsAddress,
+		OperatorSetId: 2,
+		Payload:       []byte("complex payload with special chars !@#$%^&*()"),
+	}
+
+	result := &performerTask.PerformerTaskResult{
+		TaskID: task.TaskID,
+		Result: resultPayload,
+	}
+
+	// Test
+	resultSig, authSig, err := e.signResult(task, result)
+
+	// Assert
+	assert.NoError(t, err, "Signing should succeed")
+	assert.NotEmpty(t, resultSig, "Result signature should not be empty")
+	assert.NotEmpty(t, authSig, "Auth signature should not be empty")
+	mockCaller.AssertExpectations(t)
+}
+
+// TestSignResult_MissingSignerError tests error handling when signer is not configured
+func TestSignResult_MissingSignerError(t *testing.T) {
+	// Setup
+	executorAddress := "0x1234567890123456789012345678901234567890"
+	avsAddress := "0xabcdef1234567890abcdef1234567890abcdef12"
+
+	// Create mock contract caller
+	mockCaller := NewEnhancedMockContractCaller()
+	mockCaller.SetupOperatorSetCurveType(avsAddress, 1, config.CurveTypeECDSA)
+
+	// Create executor WITHOUT signer
+	l, err := logger.NewLogger(&logger.LoggerConfig{Debug: false})
+	require.NoError(t, err)
+
+	e := &Executor{
+		config: &executorConfig.ExecutorConfig{
+			Operator: &config.OperatorConfig{
+				Address: executorAddress,
+			},
+		},
+		l1ContractCaller: mockCaller,
+		logger:           l,
+		ecdsaSigner:      nil, // No signer configured
+	}
+
+	// Create task and result
+	task := &performerTask.PerformerTask{
+		TaskID:        "0x0000000000000000000000000000000000000000000000000000000000000001",
+		Avs:           avsAddress,
+		OperatorSetId: 1,
+		Payload:       []byte("test payload"),
+	}
+
+	result := &performerTask.PerformerTaskResult{
+		TaskID: task.TaskID,
+		Result: []byte("task output data"),
+	}
+
+	// Test
+	resultSig, authSig, err := e.signResult(task, result)
+
+	// Assert
+	assert.Error(t, err, "Should fail when signer is not configured")
+	assert.Contains(t, err.Error(), "signer is not initialized", "Error should mention missing signer")
+	assert.Nil(t, resultSig, "Result signature should be nil on error")
+	assert.Nil(t, authSig, "Auth signature should be nil on error")
+
+	mockCaller.AssertExpectations(t)
+}
+
+// ============================================================================
+// Test Helper Types and Functions
+// ============================================================================
+
+// EnhancedMockContractCaller provides a more configurable mock for testing
+type EnhancedMockContractCaller struct {
+	mock.Mock
+	contractCaller.IContractCaller
+
+	// Configurable responses
+	avsConfigs   map[string]*contractCaller.AVSConfig
+	operatorSets map[string]*peering.OperatorSet
+	curveTypes   map[string]config.CurveType
+}
+
+// NewEnhancedMockContractCaller creates a new enhanced mock contract caller
+func NewEnhancedMockContractCaller() *EnhancedMockContractCaller {
+	return &EnhancedMockContractCaller{
+		avsConfigs:   make(map[string]*contractCaller.AVSConfig),
+		operatorSets: make(map[string]*peering.OperatorSet),
+		curveTypes:   make(map[string]config.CurveType),
+	}
+}
+
+// SetupValidAggregator configures a valid aggregator for testing
+func (m *EnhancedMockContractCaller) SetupValidAggregator(avsAddress, aggregatorAddress string, curveType config.CurveType) {
+	// Setup AVS config
+	m.avsConfigs[avsAddress] = &contractCaller.AVSConfig{
+		AggregatorOperatorSetId: 0,
+		ExecutorOperatorSetIds:  []uint32{1},
+	}
+
+	// Setup aggregator operator set
+	key := fmt.Sprintf("%s-%s-%d", aggregatorAddress, avsAddress, 0)
+	opSet := &peering.OperatorSet{
+		OperatorSetID: 0,
+		CurveType:     curveType,
+	}
+
+	// Set public key based on curve type
+	if curveType == config.CurveTypeECDSA {
+		opSet.WrappedPublicKey = peering.WrappedPublicKey{
+			ECDSAAddress: common.HexToAddress(aggregatorAddress),
+		}
+	}
+
+	m.operatorSets[key] = opSet
+
+	// Setup GetAVSConfig mock
+	m.On("GetAVSConfig", avsAddress).Return(m.avsConfigs[avsAddress], nil).Maybe()
+
+	// Setup GetOperatorSetDetailsForOperator mock for aggregator
+	m.On("GetOperatorSetDetailsForOperator",
+		common.HexToAddress(aggregatorAddress),
+		avsAddress,
+		uint32(0),
+	).Return(m.operatorSets[key], nil).Maybe()
+}
+
+// SetupValidOperatorSet configures a valid operator set for testing
+func (m *EnhancedMockContractCaller) SetupValidOperatorSet(operatorAddress, avsAddress string, operatorSetId uint32) {
+	key := fmt.Sprintf("%s-%s-%d", operatorAddress, avsAddress, operatorSetId)
+	m.operatorSets[key] = &peering.OperatorSet{
+		OperatorSetID: operatorSetId,
+	}
+
+	m.On("GetOperatorSetDetailsForOperator",
+		common.HexToAddress(operatorAddress),
+		avsAddress,
+		operatorSetId,
+	).Return(m.operatorSets[key], nil).Maybe()
+}
+
+// SetupOperatorSetCurveType configures the curve type for an operator set
+func (m *EnhancedMockContractCaller) SetupOperatorSetCurveType(avsAddress string, operatorSetId uint32, curveType config.CurveType) {
+	key := fmt.Sprintf("%s-%d", avsAddress, operatorSetId)
+	m.curveTypes[key] = curveType
+
+	m.On("GetOperatorSetCurveType", avsAddress, operatorSetId).Return(curveType, nil).Maybe()
+}
+
+// GetAVSConfig implementation
+func (m *EnhancedMockContractCaller) GetAVSConfig(avsAddress string) (*contractCaller.AVSConfig, error) {
+	args := m.Called(avsAddress)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*contractCaller.AVSConfig), args.Error(1)
+}
+
+// GetOperatorSetDetailsForOperator implementation
+func (m *EnhancedMockContractCaller) GetOperatorSetDetailsForOperator(operatorAddress common.Address, avsAddress string, operatorSetId uint32) (*peering.OperatorSet, error) {
+	args := m.Called(operatorAddress, avsAddress, operatorSetId)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*peering.OperatorSet), args.Error(1)
+}
+
+// GetOperatorSetCurveType implementation
+func (m *EnhancedMockContractCaller) GetOperatorSetCurveType(avsAddress string, operatorSetId uint32) (config.CurveType, error) {
+	args := m.Called(avsAddress, operatorSetId)
+	return args.Get(0).(config.CurveType), args.Error(1)
+}
+
+// CalculateBN254CertificateDigestBytes implementation
+func (m *EnhancedMockContractCaller) CalculateBN254CertificateDigestBytes(ctx context.Context, referenceTimestamp uint32, messageHash [32]byte) ([]byte, error) {
+	args := m.Called(ctx, referenceTimestamp, messageHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+// CalculateECDSACertificateDigestBytes implementation
+func (m *EnhancedMockContractCaller) CalculateECDSACertificateDigestBytes(ctx context.Context, referenceTimestamp uint32, messageHash [32]byte) ([]byte, error) {
+	args := m.Called(ctx, referenceTimestamp, messageHash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+// ConfigurableMockPerformer provides controllable behavior for testing
+type ConfigurableMockPerformer struct {
+	mock.Mock
+	avsPerformer.IAvsPerformer
+
+	// Control behavior
+	shouldFail     bool
+	customResponse []byte
+	errorMessage   string
+}
+
+// NewConfigurableMockPerformer creates a new configurable mock performer
+func NewConfigurableMockPerformer() *ConfigurableMockPerformer {
+	return &ConfigurableMockPerformer{
+		customResponse: []byte("mock result"),
+	}
+}
+
+// SetFailure configures the performer to fail
+func (p *ConfigurableMockPerformer) SetFailure(shouldFail bool, errorMessage string) {
+	p.shouldFail = shouldFail
+	p.errorMessage = errorMessage
+}
+
+// SetCustomResponse sets a custom response for the performer
+func (p *ConfigurableMockPerformer) SetCustomResponse(response []byte) {
+	p.customResponse = response
+}
+
+// RunTask implementation
+func (p *ConfigurableMockPerformer) RunTask(ctx context.Context, task *performerTask.PerformerTask) (*performerTask.PerformerTaskResult, error) {
+	// Only call if expectations were set
+	if len(p.ExpectedCalls) > 0 {
+		p.Called(ctx, task)
+	}
+
+	// Check if we should use configured behavior
+	if p.shouldFail {
+		return nil, fmt.Errorf("%s", p.errorMessage)
+	}
+
+	// Return configured response
+	return &performerTask.PerformerTaskResult{
+		TaskID: task.TaskID,
+		Result: p.customResponse,
+	}, nil
+}
+
+// ExecuteWorkflow implementation
+func (p *ConfigurableMockPerformer) ExecuteWorkflow(task *executorV1.TaskSubmission) (*executorV1.TaskResult, error) {
+	if p.shouldFail {
+		return nil, fmt.Errorf("%s", p.errorMessage)
+	}
+
+	return &executorV1.TaskResult{
+		TaskId: task.TaskId,
+		Output: p.customResponse,
+	}, nil
+}
+
+// TestSigner provides signing capabilities for tests
+type TestSigner struct {
+	privateKey interface{} // *ecdsa.PrivateKey or *bn254.PrivateKey
+	curveType  config.CurveType
+}
+
+// NewECDSATestSigner creates a test signer with ECDSA key
+func NewECDSATestSigner(privateKey *ecdsa.PrivateKey) *TestSigner {
+	return &TestSigner{
+		privateKey: privateKey,
+		curveType:  config.CurveTypeECDSA,
+	}
+}
+
+// NewBN254TestSigner creates a test signer with BN254 key
+func NewBN254TestSigner(privateKey *bn254.PrivateKey) *TestSigner {
+	return &TestSigner{
+		privateKey: privateKey,
+		curveType:  config.CurveTypeBN254,
+	}
+}
+
+// SignMessage signs a message
+func (s *TestSigner) SignMessage(data []byte) ([]byte, error) {
+	switch s.curveType {
+	case config.CurveTypeECDSA:
+		key := s.privateKey.(*ecdsa.PrivateKey)
+		hash := crypto.Keccak256Hash(data)
+		return crypto.Sign(hash.Bytes(), key)
+	case config.CurveTypeBN254:
+		key := s.privateKey.(*bn254.PrivateKey)
+		sig, err := key.Sign(data)
+		if err != nil {
+			return nil, err
+		}
+		return sig.Bytes(), nil
+	default:
+		return nil, fmt.Errorf("unsupported curve type: %v", s.curveType)
+	}
+}
+
+// SignMessageForSolidity signs a message for Solidity verification
+func (s *TestSigner) SignMessageForSolidity(data []byte) ([]byte, error) {
+	return s.SignMessage(data)
+}
+
+var _ signer.ISigner = (*TestSigner)(nil)
+
+// CreateValidTaskSubmission creates a valid task submission for testing
+func CreateValidTaskSubmission(t *testing.T, aggregatorKey interface{}, executorAddress, avsAddress string) *executorV1.TaskSubmission {
+	taskID := "0x0000000000000000000000000000000000000000000000000000000000000001"
+	operatorSetID := uint32(1)
+	payload := []byte("test payload data")
+
+	// Determine aggregator address based on key type
+	var aggregatorAddress string
+	switch key := aggregatorKey.(type) {
+	case *ecdsa.PrivateKey:
+		aggregatorAddress = crypto.PubkeyToAddress(key.PublicKey).Hex()
+	case *bn254.PrivateKey:
+		// For BN254, use a dummy address
+		aggregatorAddress = "0xaggregator00000000000000000000000000000"
+	default:
+		t.Fatalf("unsupported key type: %T", aggregatorKey)
+	}
+
+	return &executorV1.TaskSubmission{
+		TaskId:            taskID,
+		AvsAddress:        avsAddress,
+		ExecutorAddress:   executorAddress,
+		AggregatorAddress: aggregatorAddress,
+		OperatorSetId:     operatorSetID,
+		Payload:           payload,
+	}
+}
+
+// SignTaskSubmission signs a task submission with the given key
+func SignTaskSubmission(t *testing.T, task *executorV1.TaskSubmission, signerKey interface{}, executorAddress string) *executorV1.TaskSubmission {
+	// Create the message to sign
+	message := util.EncodeTaskSubmissionMessage(
+		task.TaskId,
+		task.AvsAddress,
+		executorAddress, // Use the provided executor address
+		task.OperatorSetId,
+		task.Payload,
+	)
+
+	// Sign based on key type
+	switch key := signerKey.(type) {
+	case *ecdsa.PrivateKey:
+		messageHash := crypto.Keccak256Hash(message)
+		signature, err := crypto.Sign(messageHash.Bytes(), key)
+		require.NoError(t, err)
+
+		// Convert to ECDSA signature format
+		r := new(big.Int).SetBytes(signature[:32])
+		s := new(big.Int).SetBytes(signature[32:64])
+		ecdsaSig := &ecdsacrypto.Signature{
+			V: signature[64] + 27,
+			R: r,
+			S: s,
+		}
+		task.Signature = ecdsaSig.Bytes()
+
+	case *bn254.PrivateKey:
+		sig, err := key.Sign(message)
+		require.NoError(t, err)
+		task.Signature = sig.Bytes()
+
+	default:
+		t.Fatalf("unsupported key type: %T", signerKey)
+	}
+
+	return task
+}
+
+// CreateSignedTaskSubmission creates and signs a task submission in one step
+func CreateSignedTaskSubmission(t *testing.T, aggregatorKey interface{}, executorAddress, avsAddress string) *executorV1.TaskSubmission {
+	task := CreateValidTaskSubmission(t, aggregatorKey, executorAddress, avsAddress)
+	return SignTaskSubmission(t, task, aggregatorKey, executorAddress)
+}

--- a/ponos/pkg/simulations/simulatedAggregator/simulatedAggregator.go
+++ b/ponos/pkg/simulations/simulatedAggregator/simulatedAggregator.go
@@ -39,7 +39,7 @@ func (sa *SimulatedAggregator) SubmitTaskResult(ctx context.Context, result *exe
 		zap.String("taskId", result.TaskId),
 		zap.String("operatorAddress", result.OperatorAddress),
 		zap.Any("output", result.Output),
-		zap.Binary("signature", result.Signature),
+		zap.Binary("signature", result.ResultSignature),
 	)
 
 	if sa.taskResultInspector != nil {

--- a/ponos/pkg/types/task_test.go
+++ b/ponos/pkg/types/task_test.go
@@ -1,0 +1,265 @@
+package types
+
+import (
+	"bytes"
+	"github.com/iden3/go-iden3-crypto/keccak256"
+	"testing"
+
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/util"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskSignatureData_DeterministicEncoding(t *testing.T) {
+	// Test that the same data produces the same bytes
+	var resultDigest [32]byte
+	copy(resultDigest[:], keccak256.Hash([]byte("test output")))
+	sigData1 := &AuthSignatureData{
+		TaskId:          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		AvsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1",
+		OperatorAddress: "0x5B38Da6a701c568545dCfcB03FcB875f56beddC4",
+		OperatorSetId:   42,
+		ResultSigDigest: resultDigest,
+	}
+
+	sigData2 := &AuthSignatureData{
+		TaskId:          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		AvsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1",
+		OperatorAddress: "0x5B38Da6a701c568545dCfcB03FcB875f56beddC4",
+		OperatorSetId:   42,
+		ResultSigDigest: resultDigest,
+	}
+
+	bytes1 := sigData1.ToSigningBytes()
+	bytes2 := sigData2.ToSigningBytes()
+
+	// Should be identical for same input
+	assert.Equal(t, bytes1, bytes2, "Same input should produce identical bytes")
+	assert.Equal(t, 160, len(bytes1), "Output should be exactly 160 bytes")
+
+	// Change one field and verify different output
+	sigData2.OperatorSetId = 43
+	bytes3 := sigData2.ToSigningBytes()
+	assert.NotEqual(t, bytes1, bytes3, "Different OperatorSetId should produce different bytes")
+
+	// Change another field
+	sigData2.OperatorSetId = 42 // Reset
+	var newDigest [32]byte
+	copy(newDigest[:], keccak256.Hash([]byte("different output")))
+	sigData2.ResultSigDigest = newDigest
+	bytes4 := sigData2.ToSigningBytes()
+	assert.NotEqual(t, bytes1, bytes4, "Different Output should produce different bytes")
+
+	// Test that addresses are normalized (case insensitive)
+	sigData3 := &AuthSignatureData{
+		TaskId:          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		AvsAddress:      "0x742D35CC6634C0532925A3B844BC9E7595F0BEB1", // uppercase
+		OperatorAddress: "0x5b38da6a701c568545dcfcb03fcb875f56beddc4", // lowercase
+		OperatorSetId:   42,
+		ResultSigDigest: sigData1.ResultSigDigest,
+	}
+	bytes5 := sigData3.ToSigningBytes()
+	assert.Equal(t, bytes1, bytes5, "Address case should not affect output")
+}
+
+func TestTaskSignatureData_BytesStructure(t *testing.T) {
+	var resultDigest [32]byte
+	copy(resultDigest[:], keccak256.Hash([]byte("test output")))
+	sigData := &AuthSignatureData{
+		TaskId:          "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		AvsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1",
+		OperatorAddress: "0x5B38Da6a701c568545dCfcB03FcB875f56beddC4",
+		OperatorSetId:   1,
+		ResultSigDigest: resultDigest,
+	}
+
+	signedBytes := sigData.ToSigningBytes()
+
+	// Verify total length
+	assert.Equal(t, 160, len(signedBytes), "Total length should be 160 bytes")
+
+	// Verify structure:
+	// Bytes 0-31: TaskId (32 bytes)
+	// Bytes 32-63: AvsAddress (20 bytes padded to 32)
+	// Bytes 64-95: OperatorAddress (20 bytes padded to 32)
+	// Bytes 96-127: OperatorSetId (uint32 padded to 32)
+	// Bytes 128-159: Output hash (32 bytes)
+
+	// Check that addresses are properly padded (first 12 bytes should be zeros)
+	avsAddressSection := signedBytes[32:64]
+	operatorAddressSection := signedBytes[64:96]
+
+	// First 12 bytes should be padding (zeros)
+	assert.True(t, bytes.Equal(avsAddressSection[:12], make([]byte, 12)), "AvsAddress should be left-padded with zeros")
+	assert.True(t, bytes.Equal(operatorAddressSection[:12], make([]byte, 12)), "OperatorAddress should be left-padded with zeros")
+
+	// Check OperatorSetId is properly padded (first 28 bytes should be zeros, last 4 bytes contain the uint32)
+	operatorSetIdSection := signedBytes[96:128]
+	assert.True(t, bytes.Equal(operatorSetIdSection[:28], make([]byte, 28)), "OperatorSetId should be left-padded with zeros")
+	assert.Equal(t, byte(0), operatorSetIdSection[28])
+	assert.Equal(t, byte(0), operatorSetIdSection[29])
+	assert.Equal(t, byte(0), operatorSetIdSection[30])
+	assert.Equal(t, byte(1), operatorSetIdSection[31]) // OperatorSetId = 1
+}
+
+func TestEndToEndSignatureVerification(t *testing.T) {
+	// Generate a private key for testing
+	privKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	operatorAddr := crypto.PubkeyToAddress(privKey.PublicKey)
+	hash := keccak256.Hash([]byte("result data"))
+	var resultDigest [32]byte
+	copy(resultDigest[:], keccak256.Hash(hash))
+
+	verifyData := &AuthSignatureData{
+		TaskId:          "0xdeadbeef00000000000000000000000000000000000000000000000000000000",
+		AvsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1",
+		OperatorAddress: operatorAddr.Hex(),
+		OperatorSetId:   1,
+		ResultSigDigest: resultDigest,
+	}
+
+	// Sign the data
+	signedBytes := verifyData.ToSigningBytes()
+	digest := util.GetKeccak256Digest(signedBytes)
+	sig, err := crypto.Sign(digest[:], privKey)
+	require.NoError(t, err)
+
+	// Create task result
+	taskResult := &TaskResult{
+		TaskId:          verifyData.TaskId,
+		AvsAddress:      verifyData.AvsAddress,
+		OperatorAddress: verifyData.OperatorAddress,
+		OperatorSetId:   verifyData.OperatorSetId,
+		Output:          []byte("result data"),
+		ResultSignature: sig,
+	}
+
+	verifyBytes := verifyData.ToSigningBytes()
+	verifyDigest := util.GetKeccak256Digest(verifyBytes)
+
+	// Should match original digest
+	assert.Equal(t, digest, verifyDigest, "Reconstructed digest should match original")
+
+	// Verify signature is valid
+	sigPublicKey, err := crypto.SigToPub(verifyDigest[:], taskResult.ResultSignature)
+	require.NoError(t, err)
+
+	recoveredAddr := crypto.PubkeyToAddress(*sigPublicKey)
+	assert.Equal(t, operatorAddr, recoveredAddr, "Recovered address should match operator address")
+}
+
+func TestTaskSignatureData_SecurityProperties(t *testing.T) {
+	// Test that changing any field produces a different signature
+	var resultDigest [32]byte
+	copy(resultDigest[:], keccak256.Hash([]byte("test output")))
+
+	baseData := &AuthSignatureData{
+		TaskId:          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		AvsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1",
+		OperatorAddress: "0x5B38Da6a701c568545dCfcB03FcB875f56beddC4",
+		OperatorSetId:   42,
+		ResultSigDigest: resultDigest,
+	}
+
+	baseBytes := baseData.ToSigningBytes()
+	baseDigest := util.GetKeccak256Digest(baseBytes)
+
+	// Test TaskId change
+	{
+		modified := *baseData
+		modified.TaskId = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+		modBytes := modified.ToSigningBytes()
+		modDigest := util.GetKeccak256Digest(modBytes)
+		assert.NotEqual(t, baseDigest, modDigest, "Different TaskId should produce different digest")
+	}
+
+	// Test AvsAddress change
+	{
+		modified := *baseData
+		modified.AvsAddress = "0x0000000000000000000000000000000000000001"
+		modBytes := modified.ToSigningBytes()
+		modDigest := util.GetKeccak256Digest(modBytes)
+		assert.NotEqual(t, baseDigest, modDigest, "Different AvsAddress should produce different digest")
+	}
+
+	// Test OperatorAddress change
+	{
+		modified := *baseData
+		modified.OperatorAddress = "0x0000000000000000000000000000000000000002"
+		modBytes := modified.ToSigningBytes()
+		modDigest := util.GetKeccak256Digest(modBytes)
+		assert.NotEqual(t, baseDigest, modDigest, "Different OperatorAddress should produce different digest")
+	}
+
+	// Test OperatorSetId change
+	{
+		modified := *baseData
+		modified.OperatorSetId = 999
+		modBytes := modified.ToSigningBytes()
+		modDigest := util.GetKeccak256Digest(modBytes)
+		assert.NotEqual(t, baseDigest, modDigest, "Different OperatorSetId should produce different digest")
+	}
+
+	// Test Output change
+	{
+		modified := *baseData
+		var nextDigest [32]byte
+		copy(nextDigest[:], keccak256.Hash([]byte("completely different output")))
+		modified.ResultSigDigest = nextDigest
+		modBytes := modified.ToSigningBytes()
+		modDigest := util.GetKeccak256Digest(modBytes)
+		assert.NotEqual(t, baseDigest, modDigest, "Different Output should produce different digest")
+	}
+}
+
+func TestTaskSignatureData_PreventReplayAttacks(t *testing.T) {
+	// Generate keys for two different operators
+	privKey1, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	operatorAddr1 := crypto.PubkeyToAddress(privKey1.PublicKey)
+
+	privKey2, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	operatorAddr2 := crypto.PubkeyToAddress(privKey2.PublicKey)
+
+	var resultDigest [32]byte
+	copy(resultDigest[:], keccak256.Hash([]byte("test output")))
+	// Original task for operator 1
+	originalData := &AuthSignatureData{
+		TaskId:          "0xdeadbeef00000000000000000000000000000000000000000000000000000000",
+		AvsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1",
+		OperatorAddress: operatorAddr1.Hex(),
+		OperatorSetId:   1,
+		ResultSigDigest: resultDigest,
+	}
+
+	// Sign with operator 1's key
+	signedBytes := originalData.ToSigningBytes()
+	digest := util.GetKeccak256Digest(signedBytes)
+	sig1, err := crypto.Sign(digest[:], privKey1)
+	require.NoError(t, err)
+
+	// Try to replay the same task to a different operator set
+	replayData := &AuthSignatureData{
+		TaskId:          originalData.TaskId,
+		AvsAddress:      originalData.AvsAddress,
+		OperatorAddress: operatorAddr2.Hex(), // Different operator
+		OperatorSetId:   2,                   // Different operator set
+		ResultSigDigest: originalData.ResultSigDigest,
+	}
+
+	replayBytes := replayData.ToSigningBytes()
+	replayDigest := util.GetKeccak256Digest(replayBytes)
+
+	// The digest should be different, preventing replay
+	assert.NotEqual(t, digest, replayDigest, "Different operator/set should produce different digest")
+
+	// Verify that the original signature won't validate for the replay attempt
+	sigPublicKey, err := crypto.SigToPub(replayDigest[:], sig1)
+	if err == nil {
+		recoveredAddr := crypto.PubkeyToAddress(*sigPublicKey)
+		assert.NotEqual(t, operatorAddr2, recoveredAddr, "Signature should not validate for different operator")
+	}
+}

--- a/ponos/pkg/util/signatures.go
+++ b/ponos/pkg/util/signatures.go
@@ -1,0 +1,147 @@
+package util
+
+import (
+	"encoding/binary"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// TaskSubmissionSignatureData represents data signed by aggregator for a specific executor
+type TaskSubmissionSignatureData struct {
+	TaskId          string   // 32 bytes when encoded
+	AvsAddress      string   // 20 bytes padded to 32
+	ExecutorAddress string   // 20 bytes padded to 32
+	OperatorSetId   uint32   // 4 bytes padded to 32
+	PayloadDigest   [32]byte // 32 bytes (keccak256 of payload)
+}
+
+// ToSigningBytes creates deterministic ABI-encoded bytes for signing
+// Format: taskId(bytes32) || avsAddress(address) || executorAddress(address) ||
+//
+//	operatorSetId(uint32) || payloadDigest(bytes32)
+//
+// Total: 160 bytes
+func (tsd *TaskSubmissionSignatureData) ToSigningBytes() []byte {
+	result := make([]byte, 0, 160)
+
+	// TaskId as 32 bytes
+	taskIdBytes := common.HexToHash(tsd.TaskId).Bytes()
+	result = append(result, taskIdBytes...)
+
+	// AVS address padded to 32 bytes
+	avsAddr := common.HexToAddress(tsd.AvsAddress).Bytes()
+	result = append(result, common.LeftPadBytes(avsAddr, 32)...)
+
+	// Executor address padded to 32 bytes
+	execAddr := common.HexToAddress(tsd.ExecutorAddress).Bytes()
+	result = append(result, common.LeftPadBytes(execAddr, 32)...)
+
+	// OperatorSetId as uint32 padded to 32 bytes
+	operSetId := make([]byte, 32)
+	binary.BigEndian.PutUint32(operSetId[28:], tsd.OperatorSetId)
+	result = append(result, operSetId...)
+
+	// Payload digest (already 32 bytes)
+	result = append(result, tsd.PayloadDigest[:]...)
+
+	return result
+}
+
+// TaskResultSignatureData represents data signed by executor when returning results
+type TaskResultSignatureData struct {
+	TaskId          string   // 32 bytes when encoded
+	AvsAddress      string   // 20 bytes padded to 32
+	OperatorAddress string   // 20 bytes padded to 32 (executor's own address)
+	OperatorSetId   uint32   // 4 bytes padded to 32
+	OutputDigest    [32]byte // 32 bytes (keccak256 of output)
+}
+
+// ToSigningBytes creates deterministic ABI-encoded bytes for signing
+// Same format as TaskSubmissionSignatureData for consistency
+func (trd *TaskResultSignatureData) ToSigningBytes() []byte {
+	result := make([]byte, 0, 160)
+
+	// TaskId as 32 bytes
+	taskIdBytes := common.HexToHash(trd.TaskId).Bytes()
+	result = append(result, taskIdBytes...)
+
+	// AVS address padded to 32 bytes
+	avsAddr := common.HexToAddress(trd.AvsAddress).Bytes()
+	result = append(result, common.LeftPadBytes(avsAddr, 32)...)
+
+	// Operator address padded to 32 bytes
+	operAddr := common.HexToAddress(trd.OperatorAddress).Bytes()
+	result = append(result, common.LeftPadBytes(operAddr, 32)...)
+
+	// OperatorSetId as uint32 padded to 32 bytes
+	operSetId := make([]byte, 32)
+	binary.BigEndian.PutUint32(operSetId[28:], trd.OperatorSetId)
+	result = append(result, operSetId...)
+
+	// Output digest (already 32 bytes)
+	result = append(result, trd.OutputDigest[:]...)
+
+	return result
+}
+
+// EncodeTaskSubmissionMessage creates the message to be signed by aggregator for a specific executor
+func EncodeTaskSubmissionMessage(
+	taskId string,
+	avsAddress string,
+	executorAddress string,
+	operatorSetId uint32,
+	payload []byte,
+) []byte {
+
+	payloadDigest := crypto.Keccak256Hash(payload)
+
+	sigData := &TaskSubmissionSignatureData{
+		TaskId:          taskId,
+		AvsAddress:      avsAddress,
+		ExecutorAddress: executorAddress,
+		OperatorSetId:   operatorSetId,
+		PayloadDigest:   [32]byte(payloadDigest),
+	}
+
+	return sigData.ToSigningBytes()
+}
+
+// EncodeTaskResultMessage creates the message to be signed by executor when returning results
+func EncodeTaskResultMessage(
+	taskId string,
+	avsAddress string,
+	operatorAddress string,
+	operatorSetId uint32,
+	output []byte,
+) []byte {
+
+	outputDigest := crypto.Keccak256Hash(output)
+
+	sigData := &TaskResultSignatureData{
+		TaskId:          taskId,
+		AvsAddress:      avsAddress,
+		OperatorAddress: operatorAddress,
+		OperatorSetId:   operatorSetId,
+		OutputDigest:    [32]byte(outputDigest),
+	}
+
+	return sigData.ToSigningBytes()
+}
+
+// AbiEncodeUint32 encodes a uint32 as 32 bytes (ABI standard)
+func AbiEncodeUint32(value uint32) []byte {
+	result := make([]byte, 32)
+	binary.BigEndian.PutUint32(result[28:32], value)
+	return result
+}
+
+// AbiEncodeAddress encodes an address as 32 bytes (ABI standard)
+func AbiEncodeAddress(addr string) []byte {
+	address := common.HexToAddress(addr).Bytes()
+	return common.LeftPadBytes(address, 32)
+}
+
+// AbiEncodeBytes32 encodes a hash/bytes32 value
+func AbiEncodeBytes32(value string) []byte {
+	return common.HexToHash(value).Bytes()
+}

--- a/ponos/pkg/util/signatures_test.go
+++ b/ponos/pkg/util/signatures_test.go
@@ -1,0 +1,396 @@
+package util
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeTaskSubmissionMessage(t *testing.T) {
+	tests := []struct {
+		name             string
+		taskId           string
+		avsAddress       string
+		executorAddress  string
+		operatorSetId    uint32
+		payload          []byte
+		expectedLength   int
+		checkDeterminism bool
+	}{
+		{
+			name:             "basic encoding",
+			taskId:           "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			avsAddress:       "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb2",
+			executorAddress:  "0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed",
+			operatorSetId:    42,
+			payload:          []byte("test payload"),
+			expectedLength:   160,
+			checkDeterminism: true,
+		},
+		{
+			name:             "empty payload",
+			taskId:           "0xdeadbeef",
+			avsAddress:       "0x0000000000000000000000000000000000000001",
+			executorAddress:  "0x0000000000000000000000000000000000000002",
+			operatorSetId:    0,
+			payload:          []byte{},
+			expectedLength:   160,
+			checkDeterminism: true,
+		},
+		{
+			name:             "max operator set id",
+			taskId:           "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+			avsAddress:       "0xffffffffffffffffffffffffffffffffffffffff",
+			executorAddress:  "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			operatorSetId:    ^uint32(0), // max uint32
+			payload:          []byte("another test"),
+			expectedLength:   160,
+			checkDeterminism: true,
+		},
+		{
+			name:             "addresses with mixed case",
+			taskId:           "0xABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890",
+			avsAddress:       "0xAbCdEf1234567890aBcDeF1234567890aBcDeF12",
+			executorAddress:  "0x1234567890AbCdEf1234567890AbCdEf12345678",
+			operatorSetId:    100,
+			payload:          []byte("mixed case test"),
+			expectedLength:   160,
+			checkDeterminism: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Encode the message
+			encoded := EncodeTaskSubmissionMessage(
+				tt.taskId,
+				tt.avsAddress,
+				tt.executorAddress,
+				tt.operatorSetId,
+				tt.payload,
+			)
+
+			// Check length
+			assert.Equal(t, tt.expectedLength, len(encoded), "encoded message should be exactly 160 bytes")
+
+			// Check determinism - encoding same data should produce same result
+			if tt.checkDeterminism {
+				encoded2 := EncodeTaskSubmissionMessage(
+					tt.taskId,
+					tt.avsAddress,
+					tt.executorAddress,
+					tt.operatorSetId,
+					tt.payload,
+				)
+				assert.True(t, bytes.Equal(encoded, encoded2), "encoding should be deterministic")
+			}
+
+			// Verify structure of encoded data
+			// Bytes 0-31: taskId
+			taskIdBytes := common.HexToHash(tt.taskId).Bytes()
+			assert.Equal(t, taskIdBytes, encoded[0:32], "first 32 bytes should be taskId")
+
+			// Bytes 32-63: avsAddress (padded)
+			avsAddr := common.HexToAddress(tt.avsAddress).Bytes()
+			expectedAvsBytes := common.LeftPadBytes(avsAddr, 32)
+			assert.Equal(t, expectedAvsBytes, encoded[32:64], "bytes 32-63 should be padded AVS address")
+
+			// Bytes 64-95: executorAddress (padded)
+			execAddr := common.HexToAddress(tt.executorAddress).Bytes()
+			expectedExecBytes := common.LeftPadBytes(execAddr, 32)
+			assert.Equal(t, expectedExecBytes, encoded[64:96], "bytes 64-95 should be padded executor address")
+
+			// Bytes 96-127: operatorSetId (padded)
+			// Check that the uint32 is in the last 4 bytes of the 32-byte segment
+			assert.Equal(t, byte(tt.operatorSetId>>24), encoded[124])
+			assert.Equal(t, byte(tt.operatorSetId>>16), encoded[125])
+			assert.Equal(t, byte(tt.operatorSetId>>8), encoded[126])
+			assert.Equal(t, byte(tt.operatorSetId), encoded[127])
+
+			// Bytes 128-159: payload digest
+			expectedDigest := crypto.Keccak256Hash(tt.payload)
+			assert.Equal(t, expectedDigest[:], encoded[128:160], "last 32 bytes should be payload digest")
+		})
+	}
+}
+
+func TestEncodeTaskResultMessage(t *testing.T) {
+	tests := []struct {
+		name            string
+		taskId          string
+		avsAddress      string
+		operatorAddress string
+		operatorSetId   uint32
+		output          []byte
+		expectedLength  int
+	}{
+		{
+			name:            "basic result encoding",
+			taskId:          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			avsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb2",
+			operatorAddress: "0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed",
+			operatorSetId:   42,
+			output:          []byte("task result"),
+			expectedLength:  160,
+		},
+		{
+			name:            "empty output",
+			taskId:          "0xdeadbeef",
+			avsAddress:      "0x0000000000000000000000000000000000000001",
+			operatorAddress: "0x0000000000000000000000000000000000000002",
+			operatorSetId:   0,
+			output:          []byte{},
+			expectedLength:  160,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Encode the message
+			encoded := EncodeTaskResultMessage(
+				tt.taskId,
+				tt.avsAddress,
+				tt.operatorAddress,
+				tt.operatorSetId,
+				tt.output,
+			)
+
+			// Check length
+			assert.Equal(t, tt.expectedLength, len(encoded), "encoded message should be exactly 160 bytes")
+
+			// Check determinism
+			encoded2 := EncodeTaskResultMessage(
+				tt.taskId,
+				tt.avsAddress,
+				tt.operatorAddress,
+				tt.operatorSetId,
+				tt.output,
+			)
+			assert.True(t, bytes.Equal(encoded, encoded2), "encoding should be deterministic")
+
+			// Verify structure matches TaskSubmission format (for consistency)
+			// The format should be identical, just with output instead of payload
+			outputDigest := crypto.Keccak256Hash(tt.output)
+			assert.Equal(t, outputDigest[:], encoded[128:160], "last 32 bytes should be output digest")
+		})
+	}
+}
+
+func TestSignatureDataStructures(t *testing.T) {
+	t.Run("TaskSubmissionSignatureData", func(t *testing.T) {
+		payload := []byte("test payload data")
+		payloadDigest := crypto.Keccak256Hash(payload)
+
+		sigData := &TaskSubmissionSignatureData{
+			TaskId:          "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			AvsAddress:      "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb2",
+			ExecutorAddress: "0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed",
+			OperatorSetId:   42,
+			PayloadDigest:   [32]byte(payloadDigest),
+		}
+
+		bytes := sigData.ToSigningBytes()
+		assert.Equal(t, 160, len(bytes), "signing bytes should be 160 bytes")
+
+		// Verify the same result as EncodeTaskSubmissionMessage
+		encodedDirect := EncodeTaskSubmissionMessage(
+			sigData.TaskId,
+			sigData.AvsAddress,
+			sigData.ExecutorAddress,
+			sigData.OperatorSetId,
+			payload,
+		)
+		assert.Equal(t, encodedDirect, bytes, "ToSigningBytes should match EncodeTaskSubmissionMessage")
+	})
+
+	t.Run("TaskResultSignatureData", func(t *testing.T) {
+		output := []byte("task execution result")
+		outputDigest := crypto.Keccak256Hash(output)
+
+		sigData := &TaskResultSignatureData{
+			TaskId:          "0xdeadbeef",
+			AvsAddress:      "0x0000000000000000000000000000000000000001",
+			OperatorAddress: "0x0000000000000000000000000000000000000002",
+			OperatorSetId:   100,
+			OutputDigest:    [32]byte(outputDigest),
+		}
+
+		bytes := sigData.ToSigningBytes()
+		assert.Equal(t, 160, len(bytes), "signing bytes should be 160 bytes")
+
+		// Verify the same result as EncodeTaskResultMessage
+		encodedDirect := EncodeTaskResultMessage(
+			sigData.TaskId,
+			sigData.AvsAddress,
+			sigData.OperatorAddress,
+			sigData.OperatorSetId,
+			output,
+		)
+		assert.Equal(t, encodedDirect, bytes, "ToSigningBytes should match EncodeTaskResultMessage")
+	})
+}
+
+func TestAbiEncodingHelpers(t *testing.T) {
+	t.Run("AbiEncodeUint32", func(t *testing.T) {
+		tests := []struct {
+			value    uint32
+			expected string // hex representation
+		}{
+			{0, "0000000000000000000000000000000000000000000000000000000000000000"},
+			{1, "0000000000000000000000000000000000000000000000000000000000000001"},
+			{255, "00000000000000000000000000000000000000000000000000000000000000ff"},
+			{256, "0000000000000000000000000000000000000000000000000000000000000100"},
+			{^uint32(0), "00000000000000000000000000000000000000000000000000000000ffffffff"},
+		}
+
+		for _, tt := range tests {
+			encoded := AbiEncodeUint32(tt.value)
+			assert.Equal(t, 32, len(encoded), "encoded uint32 should be 32 bytes")
+			assert.Equal(t, tt.expected, hex.EncodeToString(encoded))
+		}
+	})
+
+	t.Run("AbiEncodeAddress", func(t *testing.T) {
+		tests := []struct {
+			address  string
+			expected string // hex representation (lowercase)
+		}{
+			{
+				"0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb2",
+				"000000000000000000000000742d35cc6634c0532925a3b844bc9e7595f0beb2",
+			},
+			{
+				"0x0000000000000000000000000000000000000001",
+				"0000000000000000000000000000000000000000000000000000000000000001",
+			},
+			{
+				"0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+				"000000000000000000000000ffffffffffffffffffffffffffffffffffffffff",
+			},
+		}
+
+		for _, tt := range tests {
+			encoded := AbiEncodeAddress(tt.address)
+			assert.Equal(t, 32, len(encoded), "encoded address should be 32 bytes")
+			assert.Equal(t, tt.expected, hex.EncodeToString(encoded))
+		}
+	})
+
+	t.Run("AbiEncodeBytes32", func(t *testing.T) {
+		tests := []struct {
+			value    string
+			expected string // hex representation
+		}{
+			{
+				"0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				"1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			},
+			{
+				"0xdeadbeef",
+				"00000000000000000000000000000000000000000000000000000000deadbeef",
+			},
+			{
+				"0x00",
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			},
+		}
+
+		for _, tt := range tests {
+			encoded := AbiEncodeBytes32(tt.value)
+			assert.Equal(t, 32, len(encoded), "encoded bytes32 should be 32 bytes")
+			assert.Equal(t, tt.expected, hex.EncodeToString(encoded))
+		}
+	})
+}
+
+func TestSignatureBindingPreventsReplay(t *testing.T) {
+	// This test verifies that signatures are bound to specific executors
+	// and cannot be reused for different executors
+
+	taskId := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	avsAddress := "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb2"
+	executor1 := "0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed"
+	executor2 := "0x1111111111111111111111111111111111111111"
+	operatorSetId := uint32(42)
+	payload := []byte("important task data")
+
+	// Create messages for two different executors
+	message1 := EncodeTaskSubmissionMessage(taskId, avsAddress, executor1, operatorSetId, payload)
+	message2 := EncodeTaskSubmissionMessage(taskId, avsAddress, executor2, operatorSetId, payload)
+
+	// Messages should be different even though all other parameters are the same
+	assert.False(t, bytes.Equal(message1, message2),
+		"messages for different executors should be different")
+
+	// Verify that the only difference is in the executor address bytes (64-95)
+	assert.Equal(t, message1[0:64], message2[0:64],
+		"taskId and avsAddress should be the same")
+	assert.NotEqual(t, message1[64:96], message2[64:96],
+		"executor address bytes should be different")
+	assert.Equal(t, message1[96:], message2[96:],
+		"operatorSetId and payload digest should be the same")
+}
+
+func TestCompatibilityWithSolidityAbiEncoding(t *testing.T) {
+	// This test ensures our encoding matches Solidity's abi.encode() behavior
+	// for the message format:
+	// abi.encode(taskId, avsAddress, executorAddress, operatorSetId, payloadDigest)
+
+	taskId := "0x0000000000000000000000000000000000000000000000000000000000000001"
+	avsAddress := "0x0000000000000000000000000000000000000002"
+	executorAddress := "0x0000000000000000000000000000000000000003"
+	operatorSetId := uint32(1)
+	payload := []byte{} // empty payload for simplicity
+
+	encoded := EncodeTaskSubmissionMessage(taskId, avsAddress, executorAddress, operatorSetId, payload)
+
+	// Expected encoding:
+	// taskId:          0000000000000000000000000000000000000000000000000000000000000001
+	// avsAddress:      0000000000000000000000000000000000000000000000000000000000000002
+	// executorAddress: 0000000000000000000000000000000000000000000000000000000000000003
+	// operatorSetId:   0000000000000000000000000000000000000000000000000000000000000001
+	// payloadDigest:   c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 (keccak256 of empty)
+
+	expectedTaskId := "0000000000000000000000000000000000000000000000000000000000000001"
+	expectedAvsAddr := "0000000000000000000000000000000000000000000000000000000000000002"
+	expectedExecAddr := "0000000000000000000000000000000000000000000000000000000000000003"
+	expectedOpSetId := "0000000000000000000000000000000000000000000000000000000000000001"
+	expectedPayloadDigest := "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+
+	require.Equal(t, expectedTaskId, hex.EncodeToString(encoded[0:32]))
+	require.Equal(t, expectedAvsAddr, hex.EncodeToString(encoded[32:64]))
+	require.Equal(t, expectedExecAddr, hex.EncodeToString(encoded[64:96]))
+	require.Equal(t, expectedOpSetId, hex.EncodeToString(encoded[96:128]))
+	require.Equal(t, expectedPayloadDigest, hex.EncodeToString(encoded[128:160]))
+}
+
+func BenchmarkEncodeTaskSubmissionMessage(b *testing.B) {
+	taskId := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	avsAddress := "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb2"
+	executorAddress := "0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed"
+	operatorSetId := uint32(42)
+	payload := []byte("benchmark payload data that could be quite large in production")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = EncodeTaskSubmissionMessage(taskId, avsAddress, executorAddress, operatorSetId, payload)
+	}
+}
+
+func BenchmarkEncodeTaskResultMessage(b *testing.B) {
+	taskId := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	avsAddress := "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb2"
+	operatorAddress := "0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed"
+	operatorSetId := uint32(42)
+	output := []byte("benchmark output data that represents task execution results")
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = EncodeTaskResultMessage(taskId, avsAddress, operatorAddress, operatorSetId, output)
+	}
+}

--- a/ponos/protos/eigenlayer/hourglass/v1/executor/executor.proto
+++ b/ponos/protos/eigenlayer/hourglass/v1/executor/executor.proto
@@ -36,16 +36,17 @@ message TaskSubmission {
   bytes signature = 5;
   uint32 operator_set_id = 6;
   uint32 reference_timestamp = 7;
+  string executor_address = 8;
 }
 
 message TaskResult {
   string task_id = 1;
   string operator_address = 2;
   bytes output = 3;
-  bytes signature = 4;
+  bytes result_signature = 4;  // Signs hash(output) - for aggregation
   string avs_address = 5;
   uint32 operator_set_id = 6;
-  bytes output_digest = 7;
+  bytes auth_signature = 7;     // Signs identity data - for authentication
 }
 
 // KubernetesConfig contains Kubernetes-specific configuration for a performer


### PR DESCRIPTION
# Auth Signature Verification for Task Execution

#### Preface
This change addresses Sigma Prime critical audit findings 1 & 2 as well as well as 17, which is a medium. It's important to know the current Hourglass architecture assumes the Aggregator is a _trusted_ entity. This means there is likely some permissioning done by the AVS to admit operators into the operator set. This reduces the scope and severity of concern around trusting the values received from an Aggregator. Further, AVSs get the added benefit of being able to slash, withhold rewards, eject, etc. in the case of a bad actor.

### Problem Statement
The critical findings revolve around the fact the pre-existing flow only validates that the _payload_ was sourced from the Aggregator/Executor. This essentially leaves the door open to any attack which would cause an Executor or Aggregator, to trust the altered values of a request, like AVS address, Task Id (task hash), Executor Address, or Operator Set Id. This allows bad actors to manipulate these systems in malicious ways that benefit them or damage someone else. Some examples are given in the report, so I won't enumerate. 

### Solution Reasoning
To address this, we have improved the signing scheme between the Aggregator and Executor by signing over all values which would bind a single Executor Operator to a task. This means we're signing over the Task Id, Executor Address, Operator Set Id, AVS Address and payload. With this information, the Executor is able to independently deduce that the signature over the values it has received is indeed from the identity (key) it expects based on on-chain state. With this assertion, it can proceed with certainty that it is doing _authentic_ work.

 ## Change Summary

  Adds authentication signature verification alongside result signatures to prevent operator
  impersonation attacks during task execution.

  - Aggregation Logic: Enhanced BN254 and ECDSA aggregators to verify both result and auth signatures
    - Result signature: Signs hash(output) for consensus
    - Auth signature: Signs hash(TaskId || AvsAddress || OperatorAddress || OperatorSetId || 
  ResultSigDigest) for identity binding
  - Test Updates: Fixed aggregation tests to properly create both signatures
    - Added helper functions createSignedBN254TaskResult and createSignedECDSATaskResult
    - Converted threshold values from percentages to basis points (bips)
  - Integration Test: Updated mailbox integration test to provide proper auth signatures

  ## Key Security Improvement

  The auth signature prevents an attacker from reusing another operator's result signature by
  cryptographically binding each signature to:
  - The result signature digest 
  - The task id, task payload/response, operator address, AVS address and operator set id

This prevents attacks like replay attacks, relays between Executors and spoofing or corrupting submission data.

  ## Testing

  All aggregation tests pass with proper signature verification for both BN254 and ECDSA curves.
