### PR TITLE
fix: remove mechanism to resume inflight tasks

### DIFF
--- a/ponos/pkg/executor/executor.go
+++ b/ponos/pkg/executor/executor.go
@@ -305,7 +305,7 @@ func (e *Executor) createKubernetesPerformer(avs *executorConfig.AvsPerformerCon
 	)
 }
 
-// recoverFromStorage loads performer states from storage and verifies they're still running
+// recoverFromStorage loads performer states from storage
 func (e *Executor) recoverFromStorage(ctx context.Context) error {
 	performerStates, err := e.store.ListPerformerStates(ctx)
 	if err != nil {
@@ -324,24 +324,6 @@ func (e *Executor) recoverFromStorage(ctx context.Context) error {
 			"avsAddress", state.AvsAddress,
 			"status", state.Status,
 			"containerId", state.ContainerId,
-		)
-	}
-
-	// Load inflight tasks
-	inflightTasks, err := e.store.ListInflightTasks(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to list inflight tasks: %w", err)
-	}
-
-	e.logger.Sugar().Infow("Recovering inflight tasks from storage",
-		"count", len(inflightTasks),
-	)
-
-	for _, task := range inflightTasks {
-		e.inflightTasks.Store(task.TaskId, task)
-		e.logger.Sugar().Infow("Recovered inflight task",
-			"taskId", task.TaskId,
-			"avsAddress", task.AvsAddress,
 		)
 	}
 


### PR DESCRIPTION
The recoverFromStorage() function is responsible for restoring performer states and inflight tasks from persistent
storage after a system restart or crash. However, no operations occur on the tasks loaded into memory and these form
a memory leak.

This mechanism is fundamentally broken. The appropriate short term action is to simply remove this defunct code.