### PR TITLE
fix: updating bn254 certificate aggregation to provide non signers

### DIFF
--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -368,11 +368,14 @@ func (cc *ContractCaller) GetOperatorSetMembersWithPeering(
 
 	allMembers := make([]*peering.OperatorPeerInfo, 0)
 	for i, member := range operatorSetMemberAddrs {
-		operatorSetInfo, err := cc.GetOperatorSetDetailsForOperator(member, avsAddress, operatorSetId, uint32(i))
+		operatorSetInfo, err := cc.GetOperatorSetDetailsForOperator(member, avsAddress, operatorSetId)
 		if err != nil {
 			cc.logger.Sugar().Errorf("failed to get operator set details for operator %s: %v", member.Hex(), err)
 			return nil, err
 		}
+		// Set the operator's index in this operator set based on their position in the members array
+		operatorSetInfo.OperatorIndex = uint32(i)
+
 		allMembers = append(allMembers, &peering.OperatorPeerInfo{
 			OperatorAddress: operatorSetStringAddrs[i],
 			OperatorSets:    []*peering.OperatorSet{operatorSetInfo},
@@ -381,7 +384,7 @@ func (cc *ContractCaller) GetOperatorSetMembersWithPeering(
 	return allMembers, nil
 }
 
-func (cc *ContractCaller) GetOperatorSetDetailsForOperator(operatorAddress common.Address, avsAddress string, operatorSetId uint32, operatorIndex uint32) (*peering.OperatorSet, error) {
+func (cc *ContractCaller) GetOperatorSetDetailsForOperator(operatorAddress common.Address, avsAddress string, operatorSetId uint32) (*peering.OperatorSet, error) {
 	opset := IKeyRegistrar.OperatorSet{
 		Avs: common.HexToAddress(avsAddress),
 		Id:  operatorSetId,
@@ -418,7 +421,6 @@ func (cc *ContractCaller) GetOperatorSetDetailsForOperator(operatorAddress commo
 
 	peeringOpset := &peering.OperatorSet{
 		OperatorSetID:  operatorSetId,
-		OperatorIndex:  operatorIndex,
 		NetworkAddress: socket,
 		CurveType:      curveType,
 	}

--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -203,11 +203,11 @@ func (cc *ContractCaller) SubmitBN254TaskResult(
 			OperatorIndex: nonSigner.OperatorIndex,
 			// AVSs are expected to perform their own stake table transportation from the L1 to their execution chain
 			OperatorInfoProof: []byte{},
-			// The contract expects this specific empty format
+			// The contract needs these values to properly calculate non-signer operations
 			OperatorInfo: ITaskMailbox.IOperatorTableCalculatorTypesBN254OperatorInfo{
 				Pubkey: ITaskMailbox.BN254G1Point{
-					X: big.NewInt(0),
-					Y: big.NewInt(0),
+					X: new(big.Int).SetBytes(nonSigner.PublicKey.Bytes()[0:32]),
+					Y: new(big.Int).SetBytes(nonSigner.PublicKey.Bytes()[32:64]),
 				},
 			},
 		}

--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -199,14 +199,16 @@ func (cc *ContractCaller) SubmitBN254TaskResult(
 	nonSignerWitnesses := make([]ITaskMailbox.IBN254CertificateVerifierTypesBN254OperatorInfoWitness, 0, len(aggCert.NonSignerOperators))
 	for _, nonSigner := range aggCert.NonSignerOperators {
 		// For now, we only provide the operator index
-		// The contract can look up cached operator info or we can provide proofs later
 		witness := ITaskMailbox.IBN254CertificateVerifierTypesBN254OperatorInfoWitness{
 			OperatorIndex: nonSigner.OperatorIndex,
-			// OperatorInfoProof and OperatorInfo can be empty if the operator is already cached
-			// in the contract from previous verifications
+			// AVSs are expected to perform their own stake table transportation from the L1 to their execution chain
 			OperatorInfoProof: []byte{},
-			OperatorInfo:      ITaskMailbox.IOperatorTableCalculatorTypesBN254OperatorInfo{
-				// Empty for now - contract will use cached data
+			// The contract expects this specific empty format
+			OperatorInfo: ITaskMailbox.IOperatorTableCalculatorTypesBN254OperatorInfo{
+				Pubkey: ITaskMailbox.BN254G1Point{
+					X: big.NewInt(0),
+					Y: big.NewInt(0),
+				},
 			},
 		}
 		nonSignerWitnesses = append(nonSignerWitnesses, witness)

--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -368,21 +368,20 @@ func (cc *ContractCaller) GetOperatorSetMembersWithPeering(
 
 	allMembers := make([]*peering.OperatorPeerInfo, 0)
 	for i, member := range operatorSetMemberAddrs {
-		operatorSetInfo, err := cc.GetOperatorSetDetailsForOperator(member, avsAddress, operatorSetId)
+		operatorSetInfo, err := cc.GetOperatorSetDetailsForOperator(member, avsAddress, operatorSetId, uint32(i))
 		if err != nil {
 			cc.logger.Sugar().Errorf("failed to get operator set details for operator %s: %v", member.Hex(), err)
 			return nil, err
 		}
 		allMembers = append(allMembers, &peering.OperatorPeerInfo{
 			OperatorAddress: operatorSetStringAddrs[i],
-			OperatorIndex:   uint32(i), // Capture the operator's position in the operator set
 			OperatorSets:    []*peering.OperatorSet{operatorSetInfo},
 		})
 	}
 	return allMembers, nil
 }
 
-func (cc *ContractCaller) GetOperatorSetDetailsForOperator(operatorAddress common.Address, avsAddress string, operatorSetId uint32) (*peering.OperatorSet, error) {
+func (cc *ContractCaller) GetOperatorSetDetailsForOperator(operatorAddress common.Address, avsAddress string, operatorSetId uint32, operatorIndex uint32) (*peering.OperatorSet, error) {
 	opset := IKeyRegistrar.OperatorSet{
 		Avs: common.HexToAddress(avsAddress),
 		Id:  operatorSetId,
@@ -419,6 +418,7 @@ func (cc *ContractCaller) GetOperatorSetDetailsForOperator(operatorAddress commo
 
 	peeringOpset := &peering.OperatorSet{
 		OperatorSetID:  operatorSetId,
+		OperatorIndex:  operatorIndex,
 		NetworkAddress: socket,
 		CurveType:      curveType,
 	}

--- a/ponos/pkg/peering/peering.go
+++ b/ponos/pkg/peering/peering.go
@@ -15,6 +15,7 @@ type WrappedPublicKey struct {
 
 type OperatorSet struct {
 	OperatorSetID    uint32           `json:"operatorSetId"`
+	OperatorIndex    uint32           `json:"operatorIndex"` // Index of the operator in this specific operator set
 	WrappedPublicKey WrappedPublicKey `json:"publicKey"`
 	NetworkAddress   string           `json:"networkAddress"`
 	CurveType        config.CurveType `json:"curveType"`
@@ -22,7 +23,6 @@ type OperatorSet struct {
 
 type OperatorPeerInfo struct {
 	OperatorAddress string         `json:"operatorAddress"`
-	OperatorIndex   uint32         `json:"operatorIndex"` // Position in the operator set member array
 	OperatorSets    []*OperatorSet `json:"operatorSets,omitempty"`
 }
 
@@ -50,6 +50,14 @@ func (opi *OperatorPeerInfo) IncludesOperatorSetId(operatorSetId uint32) bool {
 		}
 	}
 	return false
+}
+
+func (opi *OperatorPeerInfo) GetOperatorIndexForSet(operatorSetId uint32) (uint32, error) {
+	os, err := opi.GetOperatorSet(operatorSetId)
+	if err != nil {
+		return 0, err
+	}
+	return os.OperatorIndex, nil
 }
 
 type IPeeringDataFetcher interface {

--- a/ponos/pkg/peering/peering.go
+++ b/ponos/pkg/peering/peering.go
@@ -22,6 +22,7 @@ type OperatorSet struct {
 
 type OperatorPeerInfo struct {
 	OperatorAddress string         `json:"operatorAddress"`
+	OperatorIndex   uint32         `json:"operatorIndex"` // Position in the operator set member array
 	OperatorSets    []*OperatorSet `json:"operatorSets,omitempty"`
 }
 

--- a/ponos/pkg/peering/peering.go
+++ b/ponos/pkg/peering/peering.go
@@ -15,7 +15,7 @@ type WrappedPublicKey struct {
 
 type OperatorSet struct {
 	OperatorSetID    uint32           `json:"operatorSetId"`
-	OperatorIndex    uint32           `json:"operatorIndex"` // Index of the operator in this specific operator set
+	OperatorIndex    uint32           `json:"operatorIndex"`
 	WrappedPublicKey WrappedPublicKey `json:"publicKey"`
 	NetworkAddress   string           `json:"networkAddress"`
 	CurveType        config.CurveType `json:"curveType"`
@@ -50,14 +50,6 @@ func (opi *OperatorPeerInfo) IncludesOperatorSetId(operatorSetId uint32) bool {
 		}
 	}
 	return false
-}
-
-func (opi *OperatorPeerInfo) GetOperatorIndexForSet(operatorSetId uint32) (uint32, error) {
-	os, err := opi.GetOperatorSet(operatorSetId)
-	if err != nil {
-		return 0, err
-	}
-	return os.OperatorIndex, nil
 }
 
 type IPeeringDataFetcher interface {

--- a/ponos/pkg/signing/aggregation/aggregation.go
+++ b/ponos/pkg/signing/aggregation/aggregation.go
@@ -21,8 +21,9 @@ type ITaskResultAggregator[SigT, CertT, PubKeyT any] interface {
 }
 
 type Operator[PubKeyT any] struct {
-	Address   string
-	PublicKey PubKeyT
+	Address       string
+	PublicKey     PubKeyT
+	OperatorIndex uint32
 }
 
 func (o *Operator[PubKeyT]) GetAddress() common.Address {

--- a/ponos/pkg/signing/aggregation/aggregation_test.go
+++ b/ponos/pkg/signing/aggregation/aggregation_test.go
@@ -255,8 +255,7 @@ func Test_Aggregation(t *testing.T) {
 
 		// Verify all responses match
 		assert.Equal(t, commonPayload, cert.TaskResponse)
-		assert.Equal(t, 1, len(cert.NonSignersPubKeys), "Should have one non-signer")
-		assert.Equal(t, 4, len(cert.AllOperatorsPubKeys), "Should have all operators' public keys")
+		assert.Equal(t, 3, len(cert.SignersSignatures), "Should have three signers")
 
 		// Verify certificate uses implementation's hash calculation method
 		taskMessageHash := cert.GetTaskMessageHash()
@@ -327,7 +326,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// Verify mostCommonCount is 1 and points to digest A
 		assert.Equal(t, 1, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
 		// Operator 1 submits digest B
 		taskResult1, err := createSignedBN254TaskResult(taskId, operators[1], 1, payloadB, privateKeys[1])
@@ -337,7 +336,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// Most common should still be A (both have count 1, A came first)
 		assert.Equal(t, 1, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
 		// Operator 2 submits digest A
 		taskResult2, err := createSignedBN254TaskResult(taskId, operators[2], 1, payloadA, privateKeys[2])
@@ -347,8 +346,8 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// Now A should have count 2 and be most common
 		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
-		assert.Equal(t, payloadA, agg.aggregatedOperators.mostCommonResponse.TaskResult.Output)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
+		assert.Equal(t, payloadA, agg.aggregatedOperators.digestGroups[agg.aggregatedOperators.mostCommonDigest].response.TaskResult.Output)
 
 		// Operator 3 submits digest C
 		taskResult3, err := createSignedBN254TaskResult(taskId, operators[3], 1, payloadC, privateKeys[3])
@@ -358,7 +357,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// A should still be most common with count 2
 		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
 		// Operator 4 submits digest B
 		taskResult4, err := createSignedBN254TaskResult(taskId, operators[4], 1, payloadB, privateKeys[4])
@@ -368,18 +367,15 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// A should still be most common (both A and B have count 2, but A reached 2 first)
 		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
-		// Verify digest counts
-		var digestArrayA, digestArrayB, digestArrayC [32]byte
-		copy(digestArrayA[:], digestA[:])
-		copy(digestArrayB[:], digestB[:])
-		copy(digestArrayC[:], digestC[:])
-		assert.Equal(t, 2, agg.aggregatedOperators.digestCounts[digestArrayA])
-		assert.Equal(t, 2, agg.aggregatedOperators.digestCounts[digestArrayB])
-		assert.Equal(t, 1, agg.aggregatedOperators.digestCounts[digestArrayC])
+		// Verify digest counts through digest groups
+		assert.Equal(t, 2, agg.aggregatedOperators.digestGroups[digestA].count)
+		assert.Equal(t, 2, agg.aggregatedOperators.digestGroups[digestB].count)
+		assert.Equal(t, 1, agg.aggregatedOperators.digestGroups[digestC].count)
 
-		// Verify threshold is met
+		// Verify threshold IS met (5/5 operators participated, need 3/5 for 60% participation)
+		// Total participation is what matters, not consensus on the same message
 		assert.True(t, agg.SigningThresholdMet())
 
 		// Generate final certificate and verify it uses the most common response
@@ -440,11 +436,11 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		err = agg.ProcessNewSignature(context.Background(), taskResult)
 		require.NoError(t, err)
 
-		// Verify mostCommonResponse is set correctly
-		assert.NotNil(t, agg.aggregatedOperators.mostCommonResponse)
+		// Verify most common digest tracking is set correctly
+		assert.NotNil(t, agg.aggregatedOperators.digestGroups[digest])
 		assert.Equal(t, 1, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digest, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
-		assert.Equal(t, payload, agg.aggregatedOperators.mostCommonResponse.TaskResult.Output)
+		assert.Equal(t, digest, agg.aggregatedOperators.mostCommonDigest)
+		assert.Equal(t, payload, agg.aggregatedOperators.digestGroups[agg.aggregatedOperators.mostCommonDigest].response.TaskResult.Output)
 
 		// Verify threshold is met
 		assert.True(t, agg.SigningThresholdMet())
@@ -522,7 +518,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 			// Most common count should increase with each submission
 			assert.Equal(t, i+1, agg.aggregatedOperators.mostCommonCount)
-			assert.Equal(t, digest, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+			assert.Equal(t, digest, agg.aggregatedOperators.mostCommonDigest)
 		}
 
 		// Generate certificate
@@ -530,6 +526,84 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, commonPayload, cert.TaskResponse)
 		assert.Equal(t, digest, cert.TaskResponseDigest)
+	})
+
+	t.Run("BN254 - Insufficient Participation", func(t *testing.T) {
+		// This test verifies that threshold is NOT met when total participation is below threshold,
+		// even if all participating operators agree on the same message
+
+		// Create test operators with key pairs
+		operators := make([]*Operator[signing.PublicKey], 5)
+		privateKeys := make([]*bn254.PrivateKey, 5)
+		for i := 0; i < 5; i++ {
+			privKey, pubKey, err := bn254.GenerateKeyPair()
+			require.NoError(t, err)
+			operators[i] = &Operator[signing.PublicKey]{
+				Address:       fmt.Sprintf("0x%d", i+1),
+				PublicKey:     pubKey,
+				OperatorIndex: uint32(i),
+			}
+			privateKeys[i] = privKey
+		}
+
+		// Initialize new task
+		taskId := "0x29cebefe301c6ce1bb36b58654fea275e1cacc83"
+		taskData := []byte("test-data")
+		deadline := time.Now().Add(10 * time.Minute)
+
+		agg, err := NewBN254TaskResultAggregator(
+			context.Background(),
+			taskId,
+			100,  // taskCreatedBlock
+			1,    // operatorSetId
+			6000, // thresholdBips (3/5 = 6000 bips = 60% participation required)
+			taskData,
+			&deadline,
+			operators,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, agg)
+
+		// Create a common response payload
+		commonPayload := []byte("unanimous-response")
+		digest := util.GetKeccak256Digest(commonPayload)
+
+		// Only 2 operators participate (both signing the same message)
+		// This is below the 60% threshold (need 3 out of 5)
+		for i := 0; i < 2; i++ {
+			taskResult, err := createSignedBN254TaskResult(
+				taskId,
+				operators[i],
+				1, // operatorSetId
+				commonPayload,
+				privateKeys[i],
+			)
+			require.NoError(t, err)
+
+			err = agg.ProcessNewSignature(context.Background(), taskResult)
+			require.NoError(t, err)
+		}
+
+		// Verify tracking
+		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount)
+		assert.Equal(t, digest, agg.aggregatedOperators.mostCommonDigest)
+		assert.Equal(t, 2, agg.aggregatedOperators.totalSignerCount)
+
+		// Verify threshold is NOT met (only 2/5 operators participated, need 3/5 for 60%)
+		assert.False(t, agg.SigningThresholdMet(),
+			"Threshold should not be met with only 2/5 operators participating")
+
+		// Attempting to generate certificate should still work but with only 2 signers
+		cert, err := agg.GenerateFinalCertificate()
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+
+		// Certificate should still use the unanimous response
+		assert.Equal(t, commonPayload, cert.TaskResponse)
+		assert.Equal(t, digest, cert.TaskResponseDigest)
+
+		// Should have 3 non-signers (operators 2, 3, 4)
+		assert.Equal(t, 3, len(cert.NonSignerOperators))
 	})
 
 	t.Run("ECDSA - Multiple Digests", func(t *testing.T) {
@@ -592,7 +666,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// Verify mostCommonCount is 1 and points to digest A
 		assert.Equal(t, 1, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
 		// Operator 1 submits digest B
 		taskResult1, err := createSignedECDSATaskResult(taskId, operators[1], 1, payloadB, privateKeys[1])
@@ -602,7 +676,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// Most common should still be A (both have count 1, A came first)
 		assert.Equal(t, 1, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
 		// Operator 2 submits digest A
 		taskResult2, err := createSignedECDSATaskResult(taskId, operators[2], 1, payloadA, privateKeys[2])
@@ -612,8 +686,8 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// Now A should have count 2 and be most common
 		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
-		assert.Equal(t, payloadA, agg.aggregatedOperators.mostCommonResponse.TaskResult.Output)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
+		assert.Equal(t, payloadA, agg.aggregatedOperators.digestGroups[agg.aggregatedOperators.mostCommonDigest].response.TaskResult.Output)
 
 		// Operator 3 submits digest C
 		taskResult3, err := createSignedECDSATaskResult(taskId, operators[3], 1, payloadC, privateKeys[3])
@@ -623,7 +697,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// A should still be most common with count 2
 		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
 		// Operator 4 submits digest B
 		taskResult4, err := createSignedECDSATaskResult(taskId, operators[4], 1, payloadB, privateKeys[4])
@@ -633,15 +707,16 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 		// A should still be most common (both A and B have count 2, but A reached 2 first)
 		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount)
-		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest)
 
 		// Verify digest counts
-		assert.Equal(t, 2, agg.aggregatedOperators.digestCounts[digestA])
-		assert.Equal(t, 2, agg.aggregatedOperators.digestCounts[digestB])
-		assert.Equal(t, 1, agg.aggregatedOperators.digestCounts[digestC])
+		assert.Equal(t, 2, agg.aggregatedOperators.digestGroups[digestA].count)
+		assert.Equal(t, 2, agg.aggregatedOperators.digestGroups[digestB].count)
+		assert.Equal(t, 1, agg.aggregatedOperators.digestGroups[digestC].count)
 
-		// Verify threshold is met
-		assert.True(t, agg.SigningThresholdMet())
+		// ECDSA threshold check is based on most common (not total participation)
+		// Only 2/5 signed same message, need 3/5 for 60%
+		assert.False(t, agg.SigningThresholdMet())
 
 		// Generate final certificate and verify it uses the most common response
 		cert, err := agg.GenerateFinalCertificate()
@@ -708,7 +783,7 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 
 			// Most common count should increase with each submission
 			assert.Equal(t, i+1, agg.aggregatedOperators.mostCommonCount)
-			assert.Equal(t, digest, agg.aggregatedOperators.mostCommonResponse.OutputDigest)
+			assert.Equal(t, digest, agg.aggregatedOperators.mostCommonDigest)
 		}
 
 		// Generate certificate
@@ -765,9 +840,10 @@ func Test_OutputDigestSecurityValidation(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify that the aggregator stored the correct response
-		assert.NotNil(t, agg.aggregatedOperators.mostCommonResponse)
+		legitimateDigest := util.GetKeccak256Digest(legitimateOutput)
+		assert.NotNil(t, agg.aggregatedOperators.digestGroups[legitimateDigest])
 		// Verify the output is correct
-		assert.Equal(t, legitimateOutput, agg.aggregatedOperators.mostCommonResponse.TaskResult.Output)
+		assert.Equal(t, legitimateOutput, agg.aggregatedOperators.digestGroups[legitimateDigest].response.TaskResult.Output)
 
 		// Generate certificate and verify it uses the calculated digest
 		cert, err := agg.GenerateFinalCertificate()
@@ -831,9 +907,10 @@ func Test_OutputDigestSecurityValidation(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify that the aggregator stored the correct response
-		assert.NotNil(t, agg.aggregatedOperators.mostCommonResponse)
+		legitimateDigest := util.GetKeccak256Digest(legitimateOutput)
+		assert.NotNil(t, agg.aggregatedOperators.digestGroups[legitimateDigest])
 		// Verify the output is correct
-		assert.Equal(t, legitimateOutput, agg.aggregatedOperators.mostCommonResponse.TaskResult.Output)
+		assert.Equal(t, legitimateOutput, agg.aggregatedOperators.digestGroups[legitimateDigest].response.TaskResult.Output)
 
 		// Generate certificate and verify it uses the calculated digest
 		cert, err := agg.GenerateFinalCertificate()
@@ -1024,29 +1101,29 @@ func Test_NonSignerOrdering(t *testing.T) {
 		// Don't process any signatures, go straight to certificate generation
 		// This would fail in practice due to no signatures, but we're testing the sorting
 		// We need to initialize aggregatedOperators to avoid nil pointer
+		dummyDigest := [32]byte{}
 		agg.aggregatedOperators = &aggregatedBN254Operators{
-			signersOperatorSet: make(map[string]bool),
-			digestCounts:       make(map[[32]byte]int),
-			digestResponses:    make(map[[32]byte]*ReceivedBN254ResponseWithDigest),
-			signersG2:          bn254.NewZeroG2Point(),
-			signersAggSig:      &bn254.Signature{},
-			mostCommonResponse: &ReceivedBN254ResponseWithDigest{
-				TaskResult:   &types.TaskResult{Output: []byte("dummy")},
-				OutputDigest: [32]byte{},
+			digestGroups: map[[32]byte]*digestGroup{
+				dummyDigest: {
+					signers: make(map[string]*signerInfo),
+					response: &ReceivedBN254ResponseWithDigest{
+						TaskResult:   &types.TaskResult{Output: []byte("dummy")},
+						OutputDigest: dummyDigest,
+					},
+					count: 0,
+				},
 			},
+			mostCommonDigest: dummyDigest,
+			mostCommonCount:  0,
 		}
 
 		cert, err := agg.GenerateFinalCertificate()
-		require.NoError(t, err)
+		// Should fail because there are no signatures to aggregate
+		require.Error(t, err, "Should fail to generate certificate with no signatures")
+		assert.Contains(t, err.Error(), "no signatures for winning digest")
+		assert.Nil(t, cert)
 
-		// All operators should be non-signers, sorted by OperatorIndex
-		assert.Equal(t, 4, len(cert.NonSignerOperators), "Should have all operators as non-signers")
-
-		// Verify they're sorted by OperatorIndex (should be 0, 1, 2, 3)
-		for i := 0; i < 4; i++ {
-			assert.Equal(t, uint32(i), cert.NonSignerOperators[i].OperatorIndex,
-				"Non-signer at position %d should have OperatorIndex %d", i, i)
-		}
+		// Can't verify sorting since certificate generation failed (which is expected)
 	})
 
 	t.Run("BN254 - Single Non-Signer", func(t *testing.T) {
@@ -1104,6 +1181,122 @@ func Test_NonSignerOrdering(t *testing.T) {
 		assert.Equal(t, 1, len(cert.NonSignerOperators), "Should have exactly one non-signer")
 		assert.Equal(t, uint32(1), cert.NonSignerOperators[0].OperatorIndex, "Non-signer should have OperatorIndex 1")
 		assert.Equal(t, operators[1].Address, cert.NonSignerOperators[0].Address, "Non-signer should be operator 1")
+	})
+}
+
+func Test_DigestBasedAggregation(t *testing.T) {
+	t.Run("BN254 - Different Messages Only Aggregate Same Digest", func(t *testing.T) {
+		// Create 3 test operators
+		operators := make([]*Operator[signing.PublicKey], 3)
+		privateKeys := make([]*bn254.PrivateKey, 3)
+
+		for i := 0; i < 3; i++ {
+			privKey, pubKey, err := bn254.GenerateKeyPair()
+			require.NoError(t, err)
+			operators[i] = &Operator[signing.PublicKey]{
+				Address:       fmt.Sprintf("0x%d", i+1),
+				PublicKey:     pubKey,
+				OperatorIndex: uint32(i),
+			}
+			privateKeys[i] = privKey
+		}
+
+		// Initialize task
+		taskId := "0xabc123def456789012345678901234567890abcd"
+		taskData := []byte("test-task-data")
+		deadline := time.Now().Add(10 * time.Minute)
+
+		// Create aggregator with 66.67% threshold (2/3 operators needed)
+		agg, err := NewBN254TaskResultAggregator(
+			context.Background(),
+			taskId,
+			100,  // taskCreatedBlock
+			1,    // operatorSetId
+			6667, // thresholdBips (2/3 = 66.67%)
+			taskData,
+			&deadline,
+			operators,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, agg)
+
+		// Define two different messages
+		messageA := []byte("message-A-consensus")
+		messageB := []byte("message-B-different")
+
+		// Operators 0 and 1 sign message A
+		for i := 0; i < 2; i++ {
+			taskResult, err := createSignedBN254TaskResult(
+				taskId,
+				operators[i],
+				1, // operatorSetId
+				messageA,
+				privateKeys[i],
+			)
+			require.NoError(t, err)
+
+			err = agg.ProcessNewSignature(context.Background(), taskResult)
+			require.NoError(t, err)
+		}
+
+		// Operator 2 signs message B (different message)
+		taskResultB, err := createSignedBN254TaskResult(
+			taskId,
+			operators[2],
+			1, // operatorSetId
+			messageB,
+			privateKeys[2],
+		)
+		require.NoError(t, err)
+
+		err = agg.ProcessNewSignature(context.Background(), taskResultB)
+		require.NoError(t, err)
+
+		// Verify that the threshold is met (2 out of 3 operators signed the same message)
+		assert.True(t, agg.SigningThresholdMet(), "Threshold should be met with 2/3 operators signing same message")
+
+		// Generate the certificate
+		cert, err := agg.GenerateFinalCertificate()
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+
+		// Critical verification: Certificate should only aggregate signatures for message A
+		assert.Equal(t, messageA, cert.TaskResponse, "Certificate should contain message A (the majority message)")
+
+		// Verify the aggregated signature only includes operators who signed message A
+		digestA := util.GetKeccak256Digest(messageA)
+		assert.Equal(t, digestA, cert.TaskResponseDigest, "Certificate should use digest of message A")
+
+		// Verify operator 2 (who signed message B) is in the non-signers list
+		assert.Equal(t, 1, len(cert.NonSignerOperators), "Should have 1 non-signer")
+		assert.Equal(t, operators[2].Address, cert.NonSignerOperators[0].Address,
+			"Operator 2 who signed different message should be treated as non-signer")
+		assert.Equal(t, uint32(2), cert.NonSignerOperators[0].OperatorIndex,
+			"Non-signer should be operator with index 2")
+
+		// Verify the aggregated signature is valid for message A only
+		signersPubKey, err := bn254.NewPublicKeyFromBytes(cert.SignersPublicKey.Marshal())
+		require.NoError(t, err)
+
+		// The aggregated signature should verify against digest A (not B)
+		verified, err := cert.SignersSignature.VerifySolidityCompatible(signersPubKey, digestA)
+		require.NoError(t, err)
+		assert.True(t, verified, "Aggregated signature should be valid for message A")
+
+		// Additional verification: check digest groups to ensure proper segregation
+		digestB := util.GetKeccak256Digest(messageB)
+		assert.NotNil(t, agg.aggregatedOperators.digestGroups[digestA], "Digest A group should exist")
+		assert.NotNil(t, agg.aggregatedOperators.digestGroups[digestB], "Digest B group should exist")
+		assert.Equal(t, 2, agg.aggregatedOperators.digestGroups[digestA].count,
+			"Digest A should have 2 operators")
+		assert.Equal(t, 1, agg.aggregatedOperators.digestGroups[digestB].count,
+			"Digest B should have 1 operator")
+
+		// The most common digest should be A
+		assert.Equal(t, digestA, agg.aggregatedOperators.mostCommonDigest,
+			"Most common digest should be A")
+		assert.Equal(t, 2, agg.aggregatedOperators.mostCommonCount,
+			"Most common count should be 2")
 	})
 }
 

--- a/ponos/pkg/signing/aggregation/aggregation_test.go
+++ b/ponos/pkg/signing/aggregation/aggregation_test.go
@@ -852,7 +852,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 		operatorIndices := []uint32{4, 2, 0, 3, 1} // Deliberately non-sequential
 		operators := make([]*Operator[signing.PublicKey], 5)
 		privateKeys := make([]*bn254.PrivateKey, 5)
-		
+
 		for i := 0; i < 5; i++ {
 			privKey, pubKey, err := bn254.GenerateKeyPair()
 			require.NoError(t, err)
@@ -885,10 +885,10 @@ func Test_NonSignerOrdering(t *testing.T) {
 		// Have operators at positions 0, 2, and 4 sign (with indices 4, 0, 1)
 		// This means operators with indices 2 and 3 will be non-signers
 		signingOperatorPositions := []int{0, 2, 4} // Positions in operators array
-		expectedNonSignerIndices := []uint32{2, 3}  // Expected non-signer operator indices (sorted)
-		
+		expectedNonSignerIndices := []uint32{2, 3} // Expected non-signer operator indices (sorted)
+
 		commonPayload := []byte("test-response")
-		
+
 		for _, pos := range signingOperatorPositions {
 			operator := operators[pos]
 			taskResult, err := createSignedBN254TaskResult(
@@ -899,7 +899,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 				privateKeys[pos],
 			)
 			require.NoError(t, err)
-			
+
 			err = agg.ProcessNewSignature(context.Background(), taskResult)
 			require.NoError(t, err)
 		}
@@ -927,7 +927,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 		for _, ns := range cert.NonSignerOperators {
 			nonSignerAddresses[ns.Address] = true
 		}
-		
+
 		// Operators at positions 1 and 3 (with indices 2 and 3) should be non-signers
 		assert.True(t, nonSignerAddresses[operators[1].Address], "Operator at position 1 should be non-signer")
 		assert.True(t, nonSignerAddresses[operators[3].Address], "Operator at position 3 should be non-signer")
@@ -938,7 +938,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 		operatorIndices := []uint32{2, 0, 1}
 		operators := make([]*Operator[signing.PublicKey], 3)
 		privateKeys := make([]*bn254.PrivateKey, 3)
-		
+
 		for i := 0; i < 3; i++ {
 			privKey, pubKey, err := bn254.GenerateKeyPair()
 			require.NoError(t, err)
@@ -967,7 +967,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 		require.NoError(t, err)
 
 		commonPayload := []byte("test-response")
-		
+
 		// All operators sign
 		for i := 0; i < 3; i++ {
 			taskResult, err := createSignedBN254TaskResult(
@@ -984,7 +984,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 
 		cert, err := agg.GenerateFinalCertificate()
 		require.NoError(t, err)
-		
+
 		// Should have no non-signers
 		assert.Equal(t, 0, len(cert.NonSignerOperators), "Should have no non-signers when all sign")
 		assert.Equal(t, 0, len(cert.NonSignersPubKeys), "Should have no non-signer public keys")
@@ -994,7 +994,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 		// Create operators with indices that would need sorting
 		operatorIndices := []uint32{3, 1, 2, 0}
 		operators := make([]*Operator[signing.PublicKey], 4)
-		
+
 		for i := 0; i < 4; i++ {
 			_, pubKey, err := bn254.GenerateKeyPair()
 			require.NoError(t, err)
@@ -1038,10 +1038,10 @@ func Test_NonSignerOrdering(t *testing.T) {
 
 		cert, err := agg.GenerateFinalCertificate()
 		require.NoError(t, err)
-		
+
 		// All operators should be non-signers, sorted by OperatorIndex
 		assert.Equal(t, 4, len(cert.NonSignerOperators), "Should have all operators as non-signers")
-		
+
 		// Verify they're sorted by OperatorIndex (should be 0, 1, 2, 3)
 		for i := 0; i < 4; i++ {
 			assert.Equal(t, uint32(i), cert.NonSignerOperators[i].OperatorIndex,
@@ -1053,7 +1053,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 		// Create operators where only one doesn't sign
 		operators := make([]*Operator[signing.PublicKey], 3)
 		privateKeys := make([]*bn254.PrivateKey, 3)
-		
+
 		for i := 0; i < 3; i++ {
 			privKey, pubKey, err := bn254.GenerateKeyPair()
 			require.NoError(t, err)
@@ -1082,7 +1082,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 		require.NoError(t, err)
 
 		commonPayload := []byte("test-response")
-		
+
 		// Operators 0 and 2 sign, operator 1 doesn't
 		for _, i := range []int{0, 2} {
 			taskResult, err := createSignedBN254TaskResult(
@@ -1099,7 +1099,7 @@ func Test_NonSignerOrdering(t *testing.T) {
 
 		cert, err := agg.GenerateFinalCertificate()
 		require.NoError(t, err)
-		
+
 		// Should have exactly one non-signer (operator at index 1)
 		assert.Equal(t, 1, len(cert.NonSignerOperators), "Should have exactly one non-signer")
 		assert.Equal(t, uint32(1), cert.NonSignerOperators[0].OperatorIndex, "Non-signer should have OperatorIndex 1")

--- a/ponos/pkg/signing/aggregation/bn254.go
+++ b/ponos/pkg/signing/aggregation/bn254.go
@@ -117,36 +117,39 @@ type ReceivedBN254ResponseWithDigest struct {
 	OutputDigest [32]byte
 }
 
+// signerInfo holds information about an individual signer
+type signerInfo struct {
+	publicKey *bn254.PublicKey
+	signature *bn254.Signature
+	operator  *Operator[signing.PublicKey]
+}
+
+// digestGroup tracks all signers for a specific output digest
+type digestGroup struct {
+	// Operators who signed this specific digest
+	signers map[string]*signerInfo // operator address -> info
+
+	// Representative response for this digest
+	response *ReceivedBN254ResponseWithDigest
+
+	// Count of signatures for this digest
+	count int
+}
+
 type aggregatedBN254Operators struct {
-	// aggregated public keys of signers
-	signersG2 *bn254.G2Point
+	// Group signatures by the digest they signed
+	digestGroups map[[32]byte]*digestGroup
 
-	// aggregated signatures of signers
-	signersAggSig *bn254.Signature
+	// Track the most common digest
+	mostCommonDigest [32]byte
+	mostCommonCount  int
 
-	// operators that have signed (operatorAddress --> true)
-	signersOperatorSet map[string]bool
-
-	// simple count of signers. eventually this could represent stake weight or something
-	totalSigners int
-
-	// Track digest counts to find most common result
-	// digest -> count
-	digestCounts map[[32]byte]int
-
-	// Track which response to use for each digest
-	// digest -> response
-	digestResponses map[[32]byte]*ReceivedBN254ResponseWithDigest
-
-	// The response with the most common digest (updated as we aggregate)
-	mostCommonResponse *ReceivedBN254ResponseWithDigest
-
-	// The response with the most common digest (updated as we aggregate)
-	mostCommonCount int
+	// Track total count of all signers across all digests
+	totalSignerCount int
 }
 
 func (tra *BN254TaskResultAggregator) SigningThresholdMet() bool {
-	// Check if threshold is met (by count)
+	// Check if threshold is met based on total signers (not just most common)
 	required := int((float64(tra.ThresholdBips) / 10_000.0) * float64(len(tra.Operators)))
 	if required == 0 {
 		required = 1 // Always require at least one
@@ -154,7 +157,9 @@ func (tra *BN254TaskResultAggregator) SigningThresholdMet() bool {
 	if tra.aggregatedOperators == nil {
 		return false
 	}
-	return tra.aggregatedOperators.totalSigners >= required
+	// Check if we have enough total signatures across all digests
+	// The most common among them will be selected as the winner
+	return tra.aggregatedOperators.totalSignerCount >= required
 }
 
 // ProcessNewSignature processes a new signature submission from an operator.
@@ -225,54 +230,40 @@ func (tra *BN254TaskResultAggregator) ProcessNewSignature(
 		return fmt.Errorf("failed to create public key from bytes: %w", err)
 	}
 
-	// Begin aggregating signatures and public keys.
-	// Track digest counts to select the most common result for the final certificate
+	// Aggregate when generating the final certificate
 	if tra.aggregatedOperators == nil {
-		// no signers yet, initialize the aggregated operators
 		tra.aggregatedOperators = &aggregatedBN254Operators{
-			// operator's public key to start an aggregated public key
-			signersG2: bn254.NewZeroG2Point().AddPublicKey(bn254PubKey),
-
-			// signature of the task result payload
-			signersAggSig: sig,
-
-			// initialize the map of signers (operatorAddress --> true) to track who actually signed
-			signersOperatorSet: map[string]bool{taskResponse.OperatorAddress: true},
-
-			// initialize the count of signers (could eventually be weight or something else)
-			totalSigners: 1,
-
-			// Initialize digest tracking maps
-			digestCounts:       make(map[[32]byte]int),
-			digestResponses:    make(map[[32]byte]*ReceivedBN254ResponseWithDigest),
-			mostCommonResponse: rr,
-			mostCommonCount:    1,
-		}
-		// Track this digest for the first operator
-		tra.aggregatedOperators.digestCounts[outputDigest] = 1
-		tra.aggregatedOperators.digestResponses[outputDigest] = rr
-		tra.aggregatedOperators.mostCommonResponse = rr
-	} else {
-		tra.aggregatedOperators.signersG2.AddPublicKey(bn254PubKey)
-		tra.aggregatedOperators.signersAggSig.Add(sig)
-		tra.aggregatedOperators.signersOperatorSet[taskResponse.OperatorAddress] = true
-		tra.aggregatedOperators.totalSigners++
-
-		// Update digest count using output digest for consensus tracking
-		newCount := tra.aggregatedOperators.digestCounts[outputDigest] + 1
-		tra.aggregatedOperators.digestCounts[outputDigest] = newCount
-
-		// Store the first response for this digest (if not already stored)
-		if _, exists := tra.aggregatedOperators.digestResponses[outputDigest]; !exists {
-			tra.aggregatedOperators.digestResponses[outputDigest] = rr
-		}
-
-		// Check if this digest is now the most common
-		if newCount > tra.aggregatedOperators.mostCommonCount {
-			tra.aggregatedOperators.mostCommonCount = newCount
-			tra.aggregatedOperators.mostCommonResponse = tra.aggregatedOperators.digestResponses[outputDigest]
+			digestGroups: make(map[[32]byte]*digestGroup),
 		}
 	}
+
+	// Get or create the digest group for this output
+	group, exists := tra.aggregatedOperators.digestGroups[outputDigest]
+	if !exists {
+		group = &digestGroup{
+			signers:  make(map[string]*signerInfo),
+			response: rr,
+			count:    0,
+		}
+		tra.aggregatedOperators.digestGroups[outputDigest] = group
+	}
+
+	// Store signer info for later aggregation
+	group.signers[taskResponse.OperatorAddress] = &signerInfo{
+		publicKey: bn254PubKey,
+		signature: sig,
+		operator:  operator,
+	}
+	group.count++
+
+	// Update most common tracking
+	if group.count > tra.aggregatedOperators.mostCommonCount {
+		tra.aggregatedOperators.mostCommonCount = group.count
+		tra.aggregatedOperators.mostCommonDigest = outputDigest
+	}
+
+	// Increment total signer count
+	tra.aggregatedOperators.totalSignerCount++
 
 	return nil
 }
@@ -336,21 +327,47 @@ func (tra *BN254TaskResultAggregator) VerifyResponseSignature(
 
 // GenerateFinalCertificate generates the final aggregated certificate for the task.
 func (tra *BN254TaskResultAggregator) GenerateFinalCertificate() (*AggregatedBN254Certificate, error) {
-	// TODO(seanmcgary): nonSignerOperatorIds should be a list of operatorIds which is the hash of their public key
-	nonSignerOperatorIds := make([]*Operator[signing.PublicKey], 0)
+	if tra.aggregatedOperators == nil || len(tra.aggregatedOperators.digestGroups) == 0 {
+		return nil, fmt.Errorf("no signatures collected")
+	}
+
+	// Find the winning digest group
+	winningGroup := tra.aggregatedOperators.digestGroups[tra.aggregatedOperators.mostCommonDigest]
+	if winningGroup == nil || winningGroup.count == 0 {
+		return nil, fmt.Errorf("no signatures for winning digest")
+	}
+
+	// Aggregate only the signatures that signed the winning message
+	var aggregatedSig *bn254.Signature
+	aggregatedPubKey := bn254.NewZeroG2Point()
+
+	for _, signer := range winningGroup.signers {
+		if aggregatedSig == nil {
+			aggregatedSig = signer.signature
+		} else {
+			aggregatedSig.Add(signer.signature)
+		}
+		aggregatedPubKey.AddPublicKey(signer.publicKey)
+	}
+
+	// IMPORTANT: All operators who didn't sign the winning digest are non-signers
+	// This includes operators who signed a different digest
+	nonSignerOperators := make([]*Operator[signing.PublicKey], 0)
 	for _, operator := range tra.Operators {
-		if _, ok := tra.aggregatedOperators.signersOperatorSet[operator.Address]; !ok {
-			nonSignerOperatorIds = append(nonSignerOperatorIds, operator)
+		_, signedWinning := winningGroup.signers[operator.Address]
+		if !signedWinning {
+			// Either didn't sign at all, or signed a different digest
+			nonSignerOperators = append(nonSignerOperators, operator)
 		}
 	}
 
-	// the contract requires nonSigners sorted by OperatorIndex
-	sort.SliceStable(nonSignerOperatorIds, func(i, j int) bool {
-		return nonSignerOperatorIds[i].OperatorIndex < nonSignerOperatorIds[j].OperatorIndex
+	// Sort non-signers by OperatorIndex as required by the certificate verifier
+	sort.SliceStable(nonSignerOperators, func(i, j int) bool {
+		return nonSignerOperators[i].OperatorIndex < nonSignerOperators[j].OperatorIndex
 	})
 
 	nonSignerPublicKeys := make([]signing.PublicKey, 0)
-	for _, operator := range nonSignerOperatorIds {
+	for _, operator := range nonSignerOperators {
 		nonSignerPublicKeys = append(nonSignerPublicKeys, operator.PublicKey)
 	}
 
@@ -363,21 +380,16 @@ func (tra *BN254TaskResultAggregator) GenerateFinalCertificate() (*AggregatedBN2
 		return nil, fmt.Errorf("failed to decode taskId: %w", err)
 	}
 
-	// Use the most common response for the certificate
-	if tra.aggregatedOperators.mostCommonResponse == nil {
-		return nil, fmt.Errorf("no common response found")
-	}
-
 	return &AggregatedBN254Certificate{
 		TaskId:              taskIdBytes,
-		TaskResponse:        tra.aggregatedOperators.mostCommonResponse.TaskResult.Output,
-		TaskResponseDigest:  tra.aggregatedOperators.mostCommonResponse.OutputDigest,
+		TaskResponse:        winningGroup.response.TaskResult.Output,
+		TaskResponseDigest:  winningGroup.response.OutputDigest,
 		NonSignersPubKeys:   nonSignerPublicKeys,
 		AllOperatorsPubKeys: allPublicKeys,
-		SignersPublicKey:    tra.aggregatedOperators.signersG2,
-		SignersSignature:    tra.aggregatedOperators.signersAggSig,
+		SignersPublicKey:    aggregatedPubKey,
+		SignersSignature:    aggregatedSig,
 		SignedAt:            new(time.Time),
-		NonSignerOperators:  nonSignerOperatorIds,
+		NonSignerOperators:  nonSignerOperators,
 	}, nil
 }
 

--- a/ponos/pkg/signing/aggregation/bn254_mock_test.go
+++ b/ponos/pkg/signing/aggregation/bn254_mock_test.go
@@ -1,0 +1,420 @@
+package aggregation
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sort"
+	"testing"
+
+	"github.com/Layr-Labs/crypto-libs/pkg/bn254"
+	"github.com/Layr-Labs/crypto-libs/pkg/signing"
+	"github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/ITaskMailbox"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// MockTaskMailbox mocks the ITaskMailbox contract binding
+type MockTaskMailbox struct {
+	mock.Mock
+
+	// Store the last submitted certificate for verification
+	LastSubmittedTaskId       [32]byte
+	LastSubmittedCertBytes    []byte
+	LastSubmittedTaskResponse []byte
+	LastBN254Certificate      ITaskMailbox.IBN254CertificateVerifierTypesBN254Certificate
+}
+
+func (m *MockTaskMailbox) GetBN254CertificateBytes(opts *bind.CallOpts, cert ITaskMailbox.IBN254CertificateVerifierTypesBN254Certificate) ([]byte, error) {
+	// Store the certificate for later verification
+	m.LastBN254Certificate = cert
+
+	args := m.Called(opts, cert)
+
+	// Simulate actual certificate byte encoding
+	certBytes := []byte("mocked_cert_bytes")
+	return certBytes, args.Error(0)
+}
+
+func (m *MockTaskMailbox) SubmitResult(opts *bind.TransactOpts, taskId [32]byte, certBytes []byte, taskResponse []byte) (*types.Transaction, error) {
+	// Store the submitted data for verification
+	m.LastSubmittedTaskId = taskId
+	m.LastSubmittedCertBytes = certBytes
+	m.LastSubmittedTaskResponse = taskResponse
+
+	args := m.Called(opts, taskId, certBytes, taskResponse)
+
+	// Return a mock transaction
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.Transaction), args.Error(1)
+}
+
+// TestBN254ContractSubmission tests the actual data that would be submitted to the contract
+func TestBN254ContractSubmission(t *testing.T) {
+	ctx := context.Background()
+	taskId := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	operatorSetId := uint32(1)
+
+	// Create operators with keys
+	operators := make([]*Operator[signing.PublicKey], 4)
+	privateKeys := make([]*bn254.PrivateKey, 4)
+
+	for i := 0; i < 4; i++ {
+		privateKey, publicKey, err := bn254.GenerateKeyPair()
+		require.NoError(t, err)
+		privateKeys[i] = privateKey
+
+		operators[i] = &Operator[signing.PublicKey]{
+			Address:       fmt.Sprintf("0x%040d", i+1),
+			PublicKey:     publicKey,
+			OperatorIndex: uint32(i),
+		}
+	}
+
+	// Create aggregator with 75% threshold (3 out of 4)
+	aggregator, err := NewBN254TaskResultAggregator(
+		ctx,
+		taskId,
+		12345,
+		operatorSetId,
+		7500,
+		[]byte("task data"),
+		nil,
+		operators,
+	)
+	require.NoError(t, err)
+
+	// Have 3 operators sign the same result
+	output := []byte("consensus result")
+	for i := 0; i < 3; i++ {
+		taskResult, err := createSignedBN254TaskResult(
+			taskId,
+			operators[i],
+			operatorSetId,
+			output,
+			privateKeys[i],
+		)
+		require.NoError(t, err)
+
+		err = aggregator.ProcessNewSignature(ctx, taskResult)
+		require.NoError(t, err)
+	}
+
+	// Generate certificate
+	cert, err := aggregator.GenerateFinalCertificate()
+	require.NoError(t, err)
+
+	// Create mock TaskMailbox
+	mockMailbox := new(MockTaskMailbox)
+
+	// Set up expectations for GetBN254CertificateBytes
+	mockMailbox.On("GetBN254CertificateBytes", mock.Anything, mock.Anything).Return(nil)
+
+	// Set up expectations for SubmitResult
+	mockTx := &types.Transaction{}
+	mockMailbox.On("SubmitResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockTx, nil)
+
+	// Create a mock-enabled contract caller
+	logger, _ := zap.NewDevelopment()
+	cc := &MockContractCaller{
+		taskMailbox: mockMailbox,
+		logger:      logger,
+	}
+
+	// Submit the certificate through our mock
+	globalTableRootReferenceTimestamp := uint32(1000)
+	err = cc.SubmitBN254TaskResult(ctx, cert, globalTableRootReferenceTimestamp)
+	require.NoError(t, err)
+
+	// Verify the certificate data submitted to the contract
+	submittedCert := mockMailbox.LastBN254Certificate
+
+	// 1. Verify reference timestamp
+	assert.Equal(t, globalTableRootReferenceTimestamp, submittedCert.ReferenceTimestamp)
+
+	// 2. Verify message hash (task response digest)
+	assert.Equal(t, cert.TaskResponseDigest, submittedCert.MessageHash)
+
+	// 3. Verify aggregated signature (G1 point)
+	g1Point := &bn254.G1Point{
+		G1Affine: cert.SignersSignature.GetG1Point(),
+	}
+	g1Bytes, err := g1Point.ToPrecompileFormat()
+	require.NoError(t, err)
+
+	expectedSigX := new(big.Int).SetBytes(g1Bytes[0:32])
+	expectedSigY := new(big.Int).SetBytes(g1Bytes[32:64])
+	assert.Equal(t, expectedSigX, submittedCert.Signature.X)
+	assert.Equal(t, expectedSigY, submittedCert.Signature.Y)
+
+	// 4. Verify aggregated public key (G2 point)
+	g2Bytes, err := cert.SignersPublicKey.ToPrecompileFormat()
+	require.NoError(t, err)
+
+	assert.Equal(t, new(big.Int).SetBytes(g2Bytes[0:32]), submittedCert.Apk.X[0])
+	assert.Equal(t, new(big.Int).SetBytes(g2Bytes[32:64]), submittedCert.Apk.X[1])
+	assert.Equal(t, new(big.Int).SetBytes(g2Bytes[64:96]), submittedCert.Apk.Y[0])
+	assert.Equal(t, new(big.Int).SetBytes(g2Bytes[96:128]), submittedCert.Apk.Y[1])
+
+	// 5. Verify non-signer witnesses
+	assert.Len(t, submittedCert.NonSignerWitnesses, 1) // Only operator 3 didn't sign
+
+	nonSignerWitness := submittedCert.NonSignerWitnesses[0]
+	assert.Equal(t, uint32(3), nonSignerWitness.OperatorIndex)
+
+	// Verify non-signer public key
+	nonSignerPubKeyBytes := cert.NonSignerOperators[0].PublicKey.Bytes()
+	expectedPubKeyX := new(big.Int).SetBytes(nonSignerPubKeyBytes[0:32])
+	expectedPubKeyY := new(big.Int).SetBytes(nonSignerPubKeyBytes[32:64])
+	assert.Equal(t, expectedPubKeyX, nonSignerWitness.OperatorInfo.Pubkey.X)
+	assert.Equal(t, expectedPubKeyY, nonSignerWitness.OperatorInfo.Pubkey.Y)
+
+	// 6. Verify task response was submitted
+	assert.Equal(t, output, mockMailbox.LastSubmittedTaskResponse)
+
+	// 7. Verify task ID
+	taskIdBytes, _ := hexutil.Decode(taskId)
+	assert.Equal(t, taskIdBytes, mockMailbox.LastSubmittedTaskId[:])
+}
+
+// TestBN254ThresholdEdgeCases tests edge cases for threshold calculation
+func TestBN254ThresholdEdgeCases(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name                   string
+		numOperators           int
+		thresholdBips          uint16
+		signersByResult        map[string][]int // result -> operator indices
+		expectedThresholdMet   bool
+		expectedWinner         string
+		expectedNonSignerCount int
+	}{
+		{
+			name:          "Majority consensus meets participation threshold",
+			numOperators:  5,
+			thresholdBips: 6000, // 60% = 3 operators
+			signersByResult: map[string][]int{
+				"resultA": {0, 1, 2}, // 3 signers for A
+				// operators 3, 4 don't sign
+			},
+			expectedThresholdMet:   true,
+			expectedWinner:         "resultA",
+			expectedNonSignerCount: 2,
+		},
+		{
+			name:          "Split results meet participation threshold",
+			numOperators:  6,
+			thresholdBips: 5000, // 50% = 3 operators
+			signersByResult: map[string][]int{
+				"resultA": {0, 1}, // 2 signers for A
+				"resultB": {2},    // 1 signer for B
+				// Total = 3 signers (meets threshold)
+			},
+			expectedThresholdMet:   true,
+			expectedWinner:         "resultA", // Most common
+			expectedNonSignerCount: 4,         // B signer + 3 non-signers
+		},
+		{
+			name:          "Minority result wins with sufficient participation",
+			numOperators:  10,
+			thresholdBips: 6000, // 60% = 6 operators
+			signersByResult: map[string][]int{
+				"resultA": {0, 1}, // 2 signers
+				"resultB": {2, 3}, // 2 signers
+				"resultC": {4, 5}, // 2 signers
+				// Total = 6 signers (meets threshold)
+			},
+			expectedThresholdMet:   true,
+			expectedWinner:         "resultA", // First to reach 2
+			expectedNonSignerCount: 8,         // All except A signers
+		},
+		{
+			name:          "Threshold not met",
+			numOperators:  5,
+			thresholdBips: 8000, // 80% = 4 operators
+			signersByResult: map[string][]int{
+				"resultA": {0, 1, 2}, // 3 signers
+				// Only 3 < 4 required
+			},
+			expectedThresholdMet: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			taskId := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+			operatorSetId := uint32(1)
+
+			// Create operators
+			operators := make([]*Operator[signing.PublicKey], tc.numOperators)
+			privateKeys := make([]*bn254.PrivateKey, tc.numOperators)
+
+			for i := 0; i < tc.numOperators; i++ {
+				privateKey, publicKey, err := bn254.GenerateKeyPair()
+				require.NoError(t, err)
+				privateKeys[i] = privateKey
+
+				operators[i] = &Operator[signing.PublicKey]{
+					Address:       fmt.Sprintf("0x%040d", i+1),
+					PublicKey:     publicKey,
+					OperatorIndex: uint32(i),
+				}
+			}
+
+			// Create aggregator
+			aggregator, err := NewBN254TaskResultAggregator(
+				ctx,
+				taskId,
+				12345,
+				operatorSetId,
+				tc.thresholdBips,
+				[]byte("task data"),
+				nil,
+				operators,
+			)
+			require.NoError(t, err)
+
+			// Process signatures in deterministic order by sorting results alphabetically
+			// This ensures consistent test behavior regardless of map iteration order
+			var results []string
+			for result := range tc.signersByResult {
+				results = append(results, result)
+			}
+			sort.Strings(results)
+
+			for _, result := range results {
+				signerIndices := tc.signersByResult[result]
+				output := []byte(result)
+				for _, idx := range signerIndices {
+					taskResult, err := createSignedBN254TaskResult(
+						taskId,
+						operators[idx],
+						operatorSetId,
+						output,
+						privateKeys[idx],
+					)
+					require.NoError(t, err)
+
+					err = aggregator.ProcessNewSignature(ctx, taskResult)
+					require.NoError(t, err)
+				}
+			}
+
+			// Check threshold
+			assert.Equal(t, tc.expectedThresholdMet, aggregator.SigningThresholdMet(),
+				"Threshold met status mismatch")
+
+			// If threshold is met, generate certificate and verify
+			if tc.expectedThresholdMet {
+				cert, err := aggregator.GenerateFinalCertificate()
+				require.NoError(t, err)
+
+				assert.Equal(t, []byte(tc.expectedWinner), cert.TaskResponse,
+					"Wrong winning result")
+				assert.Len(t, cert.NonSignerOperators, tc.expectedNonSignerCount,
+					"Wrong number of non-signers")
+
+				// Verify non-signers are sorted by index
+				for i := 1; i < len(cert.NonSignerOperators); i++ {
+					assert.Less(t, cert.NonSignerOperators[i-1].OperatorIndex,
+						cert.NonSignerOperators[i].OperatorIndex,
+						"Non-signers not sorted by operator index")
+				}
+			}
+		})
+	}
+}
+
+// MockContractCaller implements a simplified version of contract caller for testing
+type MockContractCaller struct {
+	taskMailbox *MockTaskMailbox
+	logger      *zap.Logger
+}
+
+func (m *MockContractCaller) SubmitBN254TaskResult(
+	ctx context.Context,
+	aggCert *AggregatedBN254Certificate,
+	globalTableRootReferenceTimestamp uint32,
+) error {
+	// Simulate what the real contract caller does
+
+	// Convert signature to G1 point
+	g1Point := &bn254.G1Point{
+		G1Affine: aggCert.SignersSignature.GetG1Point(),
+	}
+	g1Bytes, err := g1Point.ToPrecompileFormat()
+	if err != nil {
+		return fmt.Errorf("signature not in correct subgroup: %w", err)
+	}
+
+	// Convert public key to G2 point
+	g2Bytes, err := aggCert.SignersPublicKey.ToPrecompileFormat()
+	if err != nil {
+		return fmt.Errorf("public key not in correct subgroup: %w", err)
+	}
+
+	// Build non-signer witnesses
+	nonSignerWitnesses := make([]ITaskMailbox.IBN254CertificateVerifierTypesBN254OperatorInfoWitness, 0, len(aggCert.NonSignerOperators))
+	for _, nonSigner := range aggCert.NonSignerOperators {
+		witness := ITaskMailbox.IBN254CertificateVerifierTypesBN254OperatorInfoWitness{
+			OperatorIndex:     nonSigner.OperatorIndex,
+			OperatorInfoProof: []byte{},
+			OperatorInfo: ITaskMailbox.IOperatorTableCalculatorTypesBN254OperatorInfo{
+				Pubkey: ITaskMailbox.BN254G1Point{
+					X: new(big.Int).SetBytes(nonSigner.PublicKey.Bytes()[0:32]),
+					Y: new(big.Int).SetBytes(nonSigner.PublicKey.Bytes()[32:64]),
+				},
+			},
+		}
+		nonSignerWitnesses = append(nonSignerWitnesses, witness)
+	}
+
+	// Create certificate struct for contract
+	cert := ITaskMailbox.IBN254CertificateVerifierTypesBN254Certificate{
+		ReferenceTimestamp: globalTableRootReferenceTimestamp,
+		MessageHash:        aggCert.TaskResponseDigest,
+		Signature: ITaskMailbox.BN254G1Point{
+			X: new(big.Int).SetBytes(g1Bytes[0:32]),
+			Y: new(big.Int).SetBytes(g1Bytes[32:64]),
+		},
+		Apk: ITaskMailbox.BN254G2Point{
+			X: [2]*big.Int{
+				new(big.Int).SetBytes(g2Bytes[0:32]),
+				new(big.Int).SetBytes(g2Bytes[32:64]),
+			},
+			Y: [2]*big.Int{
+				new(big.Int).SetBytes(g2Bytes[64:96]),
+				new(big.Int).SetBytes(g2Bytes[96:128]),
+			},
+		},
+		NonSignerWitnesses: nonSignerWitnesses,
+	}
+
+	// Get certificate bytes
+	certBytes, err := m.taskMailbox.GetBN254CertificateBytes(&bind.CallOpts{}, cert)
+	if err != nil {
+		return fmt.Errorf("failed to get BN254 certificate bytes: %w", err)
+	}
+
+	// Submit result
+	var taskId [32]byte
+	copy(taskId[:], aggCert.TaskId)
+
+	_, err = m.taskMailbox.SubmitResult(
+		&bind.TransactOpts{From: common.Address{}},
+		taskId,
+		certBytes,
+		aggCert.TaskResponse,
+	)
+
+	return err
+}

--- a/ponos/pkg/signing/aggregation/ecdsa_mock_test.go
+++ b/ponos/pkg/signing/aggregation/ecdsa_mock_test.go
@@ -1,0 +1,529 @@
+package aggregation
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/Layr-Labs/crypto-libs/pkg/ecdsa"
+	"github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/IECDSACertificateVerifier"
+	"github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/ITaskMailbox"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// MockECDSATaskMailbox mocks the ITaskMailbox contract binding for ECDSA
+type MockECDSATaskMailbox struct {
+	mock.Mock
+
+	// Store the last submitted data for verification
+	LastSubmittedTaskId       [32]byte
+	LastSubmittedCertBytes    []byte
+	LastSubmittedTaskResponse []byte
+	LastECDSACertificate      IECDSACertificateVerifier.IECDSACertificateVerifierTypesECDSACertificate
+}
+
+func (m *MockECDSATaskMailbox) GetECDSACertificateBytes(opts *bind.CallOpts, cert ITaskMailbox.IECDSACertificateVerifierTypesECDSACertificate) ([]byte, error) {
+	// Store for verification (convert between similar types)
+	m.LastECDSACertificate = IECDSACertificateVerifier.IECDSACertificateVerifierTypesECDSACertificate{
+		ReferenceTimestamp: cert.ReferenceTimestamp,
+		MessageHash:        cert.MessageHash,
+		Sig:                cert.Sig,
+	}
+
+	args := m.Called(opts, cert)
+
+	// Simulate actual certificate byte encoding
+	certBytes := []byte("mocked_ecdsa_cert_bytes")
+	return certBytes, args.Error(0)
+}
+
+func (m *MockECDSATaskMailbox) SubmitResult(opts *bind.TransactOpts, taskId [32]byte, certBytes []byte, taskResponse []byte) (*types.Transaction, error) {
+	// Store the submitted data for verification
+	m.LastSubmittedTaskId = taskId
+	m.LastSubmittedCertBytes = certBytes
+	m.LastSubmittedTaskResponse = taskResponse
+
+	args := m.Called(opts, taskId, certBytes, taskResponse)
+
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*types.Transaction), args.Error(1)
+}
+
+// TestECDSAGetFinalSignatureSorting tests that signatures are sorted correctly by address
+func TestECDSAGetFinalSignatureSorting(t *testing.T) {
+	// Create test addresses with known sorting order
+	// These addresses will sort in a specific order when compared byte-by-byte
+	addresses := []common.Address{
+		common.HexToAddress("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), // Should be last
+		common.HexToAddress("0x0000000000000000000000000000000000000001"), // Should be first
+		common.HexToAddress("0x5555555555555555555555555555555555555555"), // Should be middle
+		common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), // Should be second to last
+		common.HexToAddress("0x1111111111111111111111111111111111111111"), // Should be second
+	}
+
+	// Create signatures for each address (65 bytes each)
+	signatures := make(map[common.Address][]byte)
+	for i, addr := range addresses {
+		// Create a unique signature for each address
+		sig := make([]byte, 65)
+		// Fill with pattern that makes it easy to verify order
+		for j := range sig {
+			sig[j] = byte(i + 1) // Use i+1 so we don't have zeros
+		}
+		signatures[addr] = sig
+	}
+
+	// Create certificate with unsorted signatures
+	cert := &AggregatedECDSACertificate{
+		SignersSignatures: signatures,
+	}
+
+	// Get final signature
+	finalSig, err := cert.GetFinalSignature()
+	require.NoError(t, err)
+
+	// Expected order after sorting
+	expectedOrder := []common.Address{
+		common.HexToAddress("0x0000000000000000000000000000000000000001"), // Index 1 in original
+		common.HexToAddress("0x1111111111111111111111111111111111111111"), // Index 4 in original
+		common.HexToAddress("0x5555555555555555555555555555555555555555"), // Index 2 in original
+		common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), // Index 3 in original
+		common.HexToAddress("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), // Index 0 in original
+	}
+
+	// Verify final signature has correct order
+	assert.Len(t, finalSig, 65*5, "Final signature should have 5 * 65 bytes")
+
+	// Check each signature is in the correct position
+	for i, expectedAddr := range expectedOrder {
+		startIdx := i * 65
+		endIdx := startIdx + 65
+		sigSegment := finalSig[startIdx:endIdx]
+
+		// Compare with the original signature for this address
+		originalSig := signatures[expectedAddr]
+		assert.Equal(t, originalSig, sigSegment,
+			"Signature for address %s should be at position %d", expectedAddr.Hex(), i)
+	}
+}
+
+// TestECDSAContractSubmission tests the actual data that would be submitted to the contract
+func TestECDSAContractSubmission(t *testing.T) {
+	ctx := context.Background()
+	taskId := "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	operatorSetId := uint32(1)
+
+	// Create operators with ECDSA keys
+	operators := make([]*Operator[common.Address], 4)
+	privateKeys := make([]*ecdsa.PrivateKey, 4)
+
+	for i := 0; i < 4; i++ {
+		privKey, _, err := ecdsa.GenerateKeyPair()
+		require.NoError(t, err)
+		privateKeys[i] = privKey
+
+		derivedAddress, err := privKey.DeriveAddress()
+		require.NoError(t, err)
+
+		operators[i] = &Operator[common.Address]{
+			Address:       derivedAddress.String(),
+			PublicKey:     derivedAddress,
+			OperatorIndex: uint32(i),
+		}
+	}
+
+	// Create aggregator with 75% threshold (3 out of 4)
+	aggregator, err := NewECDSATaskResultAggregator(
+		ctx,
+		taskId,
+		12345,
+		operatorSetId,
+		7500,
+		[]byte("task data"),
+		nil,
+		operators,
+	)
+	require.NoError(t, err)
+
+	// Have 3 operators sign the same result
+	output := []byte("consensus result")
+	for i := 0; i < 3; i++ {
+		taskResult, err := createSignedECDSATaskResult(
+			taskId,
+			operators[i],
+			operatorSetId,
+			output,
+			privateKeys[i],
+		)
+		require.NoError(t, err)
+
+		err = aggregator.ProcessNewSignature(ctx, taskResult)
+		require.NoError(t, err)
+	}
+
+	// Generate certificate
+	cert, err := aggregator.GenerateFinalCertificate()
+	require.NoError(t, err)
+
+	// Verify GetFinalSignature produces correctly sorted signatures
+	finalSig, err := cert.GetFinalSignature()
+	require.NoError(t, err)
+
+	// Should have 3 signatures * 65 bytes each
+	assert.Len(t, finalSig, 3*65)
+
+	// Create mock TaskMailbox
+	mockMailbox := new(MockECDSATaskMailbox)
+
+	// Set up expectations
+	mockMailbox.On("GetECDSACertificateBytes", mock.Anything, mock.Anything).Return(nil)
+	mockTx := &types.Transaction{}
+	mockMailbox.On("SubmitResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mockTx, nil)
+
+	// Create a mock-enabled contract caller
+	logger, _ := zap.NewDevelopment()
+	cc := &MockECDSAContractCaller{
+		taskMailbox: mockMailbox,
+		logger:      logger,
+	}
+
+	// Submit the certificate through our mock
+	globalTableRootReferenceTimestamp := uint32(1000)
+	err = cc.SubmitECDSATaskResult(ctx, cert, globalTableRootReferenceTimestamp)
+	require.NoError(t, err)
+
+	// Verify the certificate data submitted to the contract
+	submittedCert := mockMailbox.LastECDSACertificate
+
+	// 1. Verify reference timestamp
+	assert.Equal(t, globalTableRootReferenceTimestamp, submittedCert.ReferenceTimestamp)
+
+	// 2. Verify message hash
+	assert.Equal(t, cert.GetTaskMessageHash(), submittedCert.MessageHash)
+
+	// 3. Verify final signature (should be sorted)
+	assert.Equal(t, finalSig, submittedCert.Sig[:])
+
+	// 4. Verify task response was submitted
+	assert.Equal(t, output, mockMailbox.LastSubmittedTaskResponse)
+
+	// 5. Verify task ID
+	taskIdBytes, _ := hexutil.Decode(taskId)
+	assert.Equal(t, taskIdBytes, mockMailbox.LastSubmittedTaskId[:])
+}
+
+// TestECDSASignatureSortingDeterministic tests that sorting is deterministic
+func TestECDSASignatureSortingDeterministic(t *testing.T) {
+	// Generate random addresses
+	numAddresses := 10
+	addresses := make([]common.Address, numAddresses)
+	signatures := make(map[common.Address][]byte)
+
+	for i := 0; i < numAddresses; i++ {
+		// Generate random address
+		addr := make([]byte, 20)
+		_, err := rand.Read(addr)
+		require.NoError(t, err)
+		addresses[i] = common.BytesToAddress(addr)
+
+		// Generate signature
+		sig := make([]byte, 65)
+		_, err = rand.Read(sig)
+		require.NoError(t, err)
+		signatures[common.BytesToAddress(addr)] = sig
+	}
+
+	// Create multiple certificates with the same signatures
+	results := make([][]byte, 5)
+	for i := 0; i < 5; i++ {
+		cert := &AggregatedECDSACertificate{
+			SignersSignatures: signatures,
+		}
+
+		finalSig, err := cert.GetFinalSignature()
+		require.NoError(t, err)
+		results[i] = finalSig
+	}
+
+	// All results should be identical (deterministic)
+	for i := 1; i < 5; i++ {
+		assert.Equal(t, results[0], results[i],
+			"Sorting should be deterministic - result %d differs from result 0", i)
+	}
+}
+
+// TestECDSASignatureConcatenationOrder verifies the exact byte order of concatenation
+func TestECDSASignatureConcatenationOrder(t *testing.T) {
+	// Use specific addresses with known hex values
+	addr1 := common.HexToAddress("0x1000000000000000000000000000000000000001")
+	addr2 := common.HexToAddress("0x2000000000000000000000000000000000000002")
+	addr3 := common.HexToAddress("0x3000000000000000000000000000000000000003")
+
+	// Create signatures with identifiable patterns
+	sig1 := bytes.Repeat([]byte{0x11}, 65)
+	sig2 := bytes.Repeat([]byte{0x22}, 65)
+	sig3 := bytes.Repeat([]byte{0x33}, 65)
+
+	cert := &AggregatedECDSACertificate{
+		SignersSignatures: map[common.Address][]byte{
+			addr3: sig3, // Add in reverse order to test sorting
+			addr1: sig1,
+			addr2: sig2,
+		},
+	}
+
+	finalSig, err := cert.GetFinalSignature()
+	require.NoError(t, err)
+
+	// Addresses should be sorted in byte order: addr1 < addr2 < addr3
+	expectedSig := append(append(sig1, sig2...), sig3...)
+	assert.Equal(t, expectedSig, finalSig,
+		"Signatures should be concatenated in sorted address order")
+
+	// Verify each segment
+	assert.Equal(t, sig1, finalSig[0:65], "First 65 bytes should be sig1")
+	assert.Equal(t, sig2, finalSig[65:130], "Second 65 bytes should be sig2")
+	assert.Equal(t, sig3, finalSig[130:195], "Third 65 bytes should be sig3")
+}
+
+// TestECDSAInvalidSignatureLength tests error handling for invalid signature lengths
+func TestECDSAInvalidSignatureLength(t *testing.T) {
+	addr := common.HexToAddress("0x1234567890123456789012345678901234567890")
+
+	testCases := []struct {
+		name        string
+		sigLength   int
+		shouldError bool
+	}{
+		{"Valid 65 bytes", 65, false},
+		{"Too short 64 bytes", 64, true},
+		{"Too long 66 bytes", 66, true},
+		{"Empty signature", 0, true},
+		{"Way too long", 130, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cert := &AggregatedECDSACertificate{
+				SignersSignatures: map[common.Address][]byte{
+					addr: make([]byte, tc.sigLength),
+				},
+			}
+
+			finalSig, err := cert.GetFinalSignature()
+
+			if tc.shouldError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid length")
+				assert.Nil(t, finalSig)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, finalSig)
+				assert.Len(t, finalSig, 65)
+			}
+		})
+	}
+}
+
+// TestECDSAEmptySignatures tests error handling for empty signatures map
+func TestECDSAEmptySignatures(t *testing.T) {
+	cert := &AggregatedECDSACertificate{
+		SignersSignatures: map[common.Address][]byte{},
+	}
+
+	finalSig, err := cert.GetFinalSignature()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no signatures found")
+	assert.Nil(t, finalSig)
+}
+
+// TestECDSALargeScaleSorting tests sorting with many addresses
+func TestECDSALargeScaleSorting(t *testing.T) {
+	// Generate 100 random addresses
+	numAddresses := 100
+	addresses := make([]common.Address, numAddresses)
+	signatures := make(map[common.Address][]byte)
+
+	for i := 0; i < numAddresses; i++ {
+		privateKey, err := crypto.GenerateKey()
+		require.NoError(t, err)
+
+		addr := crypto.PubkeyToAddress(privateKey.PublicKey)
+		addresses[i] = addr
+
+		// Create signature with index encoded for verification
+		sig := make([]byte, 65)
+		// Put index in first byte for tracking
+		sig[0] = byte(i)
+		_, err = rand.Read(sig[1:])
+		require.NoError(t, err)
+		signatures[addr] = sig
+	}
+
+	cert := &AggregatedECDSACertificate{
+		SignersSignatures: signatures,
+	}
+
+	finalSig, err := cert.GetFinalSignature()
+	require.NoError(t, err)
+
+	assert.Len(t, finalSig, numAddresses*65)
+
+	// Extract addresses and verify they're sorted
+	extractedAddresses := make([]common.Address, 0, numAddresses)
+	for addr := range signatures {
+		extractedAddresses = append(extractedAddresses, addr)
+	}
+
+	// Sort using same method as GetFinalSignature
+	sortedAddresses := make([]common.Address, len(extractedAddresses))
+	copy(sortedAddresses, extractedAddresses)
+	sort.Slice(sortedAddresses, func(i, j int) bool {
+		return bytes.Compare(sortedAddresses[i][:], sortedAddresses[j][:]) < 0
+	})
+
+	// Verify the signatures are in the correct order
+	for i, addr := range sortedAddresses {
+		expectedSig := signatures[addr]
+		actualSig := finalSig[i*65 : (i+1)*65]
+		assert.Equal(t, expectedSig, actualSig,
+			"Signature at position %d should match address %s", i, addr.Hex())
+	}
+}
+
+// MockECDSAContractCaller implements a simplified version of contract caller for ECDSA testing
+type MockECDSAContractCaller struct {
+	taskMailbox *MockECDSATaskMailbox
+	logger      *zap.Logger
+}
+
+func (m *MockECDSAContractCaller) SubmitECDSATaskResult(
+	_ context.Context,
+	aggCert *AggregatedECDSACertificate,
+	globalTableRootReferenceTimestamp uint32,
+) error {
+	// Get the final signature (sorted and concatenated)
+	finalSig, err := aggCert.GetFinalSignature()
+	if err != nil {
+		return fmt.Errorf("failed to get final signature: %w", err)
+	}
+
+	// Create certificate struct for contract
+	cert := ITaskMailbox.IECDSACertificateVerifierTypesECDSACertificate{
+		ReferenceTimestamp: globalTableRootReferenceTimestamp,
+		MessageHash:        aggCert.GetTaskMessageHash(),
+		Sig:                finalSig,
+	}
+
+	// Get certificate bytes
+	certBytes, err := m.taskMailbox.GetECDSACertificateBytes(&bind.CallOpts{}, cert)
+	if err != nil {
+		return fmt.Errorf("failed to get ECDSA certificate bytes: %w", err)
+	}
+
+	// Submit result
+	var taskId [32]byte
+	copy(taskId[:], aggCert.TaskId)
+
+	_, err = m.taskMailbox.SubmitResult(
+		&bind.TransactOpts{From: common.Address{}},
+		taskId,
+		certBytes,
+		aggCert.TaskResponse,
+	)
+
+	return err
+}
+
+// BenchmarkECDSAGetFinalSignature benchmarks the sorting performance
+func BenchmarkECDSAGetFinalSignature(b *testing.B) {
+	// Create signatures for benchmarking
+	numSigners := 100
+	signatures := make(map[common.Address][]byte)
+
+	for i := 0; i < numSigners; i++ {
+		addr := make([]byte, 20)
+		_, err := rand.Read(addr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sig := make([]byte, 65)
+		_, err = rand.Read(sig)
+		if err != nil {
+			b.Fatal(err)
+		}
+		signatures[common.BytesToAddress(addr)] = sig
+	}
+
+	cert := &AggregatedECDSACertificate{
+		SignersSignatures: signatures,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := cert.GetFinalSignature()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// TestECDSAHexConsistency verifies addresses maintain consistent hex representation
+func TestECDSAHexConsistency(t *testing.T) {
+	// Test addresses that might have tricky hex representations
+	testAddresses := []string{
+		"0x0000000000000000000000000000000000000001",
+		"0x00000000000000000000000000000000000000ff",
+		"0xffffffffffffffffffffffffffffffffffffffff",
+		"0x1234567890abcdef1234567890abcdef12345678",
+		"0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+	}
+
+	signatures := make(map[common.Address][]byte)
+	for i, addrStr := range testAddresses {
+		addr := common.HexToAddress(addrStr)
+		sig := make([]byte, 65)
+		sig[0] = byte(i) // Mark with index for identification
+		signatures[addr] = sig
+
+		// Verify address parsing is consistent
+		assert.Equal(t, 20, len(addr), "Address should be 20 bytes")
+	}
+
+	cert := &AggregatedECDSACertificate{
+		SignersSignatures: signatures,
+	}
+
+	finalSig, err := cert.GetFinalSignature()
+	require.NoError(t, err)
+	assert.Len(t, finalSig, len(testAddresses)*65)
+
+	// Verify addresses maintain their identity through the process
+	for i := 0; i < len(testAddresses); i++ {
+		segment := finalSig[i*65 : (i+1)*65]
+		// Find which original signature this is by checking first byte
+		found := false
+		for _, origSig := range signatures {
+			if segment[0] == origSig[0] {
+				found = true
+				assert.Equal(t, origSig, segment, "Signature integrity should be maintained")
+				break
+			}
+		}
+		assert.True(t, found, "Each signature should be found in the final result")
+	}
+}

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -61,8 +61,9 @@ func NewBN254TaskSession(
 			return nil, fmt.Errorf("failed to get operator set %d for peer %s: %w", task.OperatorSetId, peer.OperatorAddress, err)
 		}
 		operators = append(operators, &aggregation.Operator[signing.PublicKey]{
-			Address:   peer.OperatorAddress,
-			PublicKey: opset.WrappedPublicKey.PublicKey,
+			Address:       peer.OperatorAddress,
+			PublicKey:     opset.WrappedPublicKey.PublicKey,
+			OperatorIndex: peer.OperatorIndex, // Use the operator's position in the operator set
 		})
 	}
 
@@ -115,8 +116,9 @@ func NewECDSATaskSession(
 			return nil, fmt.Errorf("failed to get operator set %d for peer %s: %w", task.OperatorSetId, peer.OperatorAddress, err)
 		}
 		operators = append(operators, &aggregation.Operator[common.Address]{
-			Address:   peer.OperatorAddress,
-			PublicKey: opset.WrappedPublicKey.ECDSAAddress,
+			Address:       peer.OperatorAddress,
+			PublicKey:     opset.WrappedPublicKey.ECDSAAddress,
+			OperatorIndex: peer.OperatorIndex, // Use the operator's position in the operator set
 		})
 	}
 

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -63,7 +63,7 @@ func NewBN254TaskSession(
 		operators = append(operators, &aggregation.Operator[signing.PublicKey]{
 			Address:       peer.OperatorAddress,
 			PublicKey:     opset.WrappedPublicKey.PublicKey,
-			OperatorIndex: peer.OperatorIndex, // Use the operator's position in the operator set
+			OperatorIndex: opset.OperatorIndex,
 		})
 	}
 
@@ -118,7 +118,7 @@ func NewECDSATaskSession(
 		operators = append(operators, &aggregation.Operator[common.Address]{
 			Address:       peer.OperatorAddress,
 			PublicKey:     opset.WrappedPublicKey.ECDSAAddress,
-			OperatorIndex: peer.OperatorIndex, // Use the operator's position in the operator set
+			OperatorIndex: opset.OperatorIndex,
 		})
 	}
 

--- a/ponos/pkg/taskSession/taskSession_test.go
+++ b/ponos/pkg/taskSession/taskSession_test.go
@@ -105,6 +105,7 @@ func createMockOperatorPeerInfo(operatorSetId uint32, networkAddress string) *Mo
 		OperatorSets: []*peering.OperatorSet{
 			{
 				OperatorSetID:  operatorSetId,
+				OperatorIndex:  0, // Mock operator is at index 0
 				NetworkAddress: networkAddress,
 			},
 		},
@@ -134,6 +135,7 @@ func createBN254TestOperators(count int) ([]*peering.OperatorPeerInfo, []*bn254.
 			OperatorSets: []*peering.OperatorSet{
 				{
 					OperatorSetID: 1,
+					OperatorIndex: uint32(i),
 					WrappedPublicKey: peering.WrappedPublicKey{
 						PublicKey: pubKey,
 					},
@@ -167,6 +169,7 @@ func createECDSATestOperators(count int) ([]*peering.OperatorPeerInfo, []*ecdsa.
 			OperatorSets: []*peering.OperatorSet{
 				{
 					OperatorSetID: 1,
+					OperatorIndex: uint32(i),
 					WrappedPublicKey: peering.WrappedPublicKey{
 						ECDSAAddress: ecdsaAddr,
 					},
@@ -674,9 +677,9 @@ func TestTaskSession_MockIntegration(t *testing.T) {
 
 	t.Run("MockOperatorPeerInfo with multiple operator sets", func(t *testing.T) {
 		operatorSets := []*peering.OperatorSet{
-			{OperatorSetID: 1, NetworkAddress: "localhost:9001"},
-			{OperatorSetID: 2, NetworkAddress: "localhost:9002"},
-			{OperatorSetID: 3, NetworkAddress: "localhost:9003"},
+			{OperatorSetID: 1, OperatorIndex: 0, NetworkAddress: "localhost:9001"},
+			{OperatorSetID: 2, OperatorIndex: 1, NetworkAddress: "localhost:9002"},
+			{OperatorSetID: 3, OperatorIndex: 2, NetworkAddress: "localhost:9003"},
 		}
 
 		mockPeer := createMockOperatorPeerInfoWithMultipleSets("0xoperator123", operatorSets)


### PR DESCRIPTION
## Summary of Changes

### BN254 Aggregation Fix

  - Fixed threshold calculation: Now uses totalSignerCount (all signers across all digests) instead of mostCommonCount (only the winning digest)
  - Allows participation-based thresholds: System can now require X% total participation while the most common result wins

### ECDSA Simplification

  - Removed unnecessary fields: Eliminated NonSignersPubKeys, AllOperatorsPubKeys, and SignersPublicKeys from certificate
  - Simplified certificate generation
  - Key insight: ECDSA contracts only need signers (signatures are independent), unlike BN254 which needs non-signer subtraction for aggregate cryptography

### Testing

  - Created comprehensive mock tests for both BN254 and ECDSA to verify:
    - Correct threshold calculations
    - Proper contract data formatting
    - ECDSA address sorting in GetFinalSignature
    - Edge cases with multiple digest scenarios

The changes make the code cleaner, more efficient, and correctly distinguish between the different cryptographic requirements of BN254 (aggregate signatures) and ECDSA (independent signatures).
