### PR TITLE
fix: sending blocknumber to the executor for the task

### DIFF
--- a/ponos/gen/protos/eigenlayer/hourglass/v1/executor/executor.pb.go
+++ b/ponos/gen/protos/eigenlayer/hourglass/v1/executor/executor.pb.go
@@ -33,6 +33,7 @@ type TaskSubmission struct {
 	OperatorSetId      uint32                 `protobuf:"varint,6,opt,name=operator_set_id,json=operatorSetId,proto3" json:"operator_set_id,omitempty"`
 	ReferenceTimestamp uint32                 `protobuf:"varint,7,opt,name=reference_timestamp,json=referenceTimestamp,proto3" json:"reference_timestamp,omitempty"`
 	ExecutorAddress    string                 `protobuf:"bytes,8,opt,name=executor_address,json=executorAddress,proto3" json:"executor_address,omitempty"`
+	TaskBlockNumber    uint64                 `protobuf:"varint,9,opt,name=task_block_number,json=taskBlockNumber,proto3" json:"task_block_number,omitempty"` // Block number for consistent state queries
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -121,6 +122,13 @@ func (x *TaskSubmission) GetExecutorAddress() string {
 		return x.ExecutorAddress
 	}
 	return ""
+}
+
+func (x *TaskSubmission) GetTaskBlockNumber() uint64 {
+	if x != nil {
+		return x.TaskBlockNumber
+	}
+	return 0
 }
 
 type TaskResult struct {
@@ -1101,7 +1109,7 @@ var File_eigenlayer_hourglass_v1_executor_executor_proto protoreflect.FileDescri
 
 const file_eigenlayer_hourglass_v1_executor_executor_proto_rawDesc = "" +
 	"\n" +
-	"/eigenlayer/hourglass/v1/executor/executor.proto\x12\x17eigenlayer.hourglass.v1\x1a)eigenlayer/hourglass/v1/common/auth.proto\"\xb5\x02\n" +
+	"/eigenlayer/hourglass/v1/executor/executor.proto\x12\x17eigenlayer.hourglass.v1\x1a)eigenlayer/hourglass/v1/common/auth.proto\"\xe1\x02\n" +
 	"\x0eTaskSubmission\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12-\n" +
 	"\x12aggregator_address\x18\x02 \x01(\tR\x11aggregatorAddress\x12\x1f\n" +
@@ -1111,7 +1119,8 @@ const file_eigenlayer_hourglass_v1_executor_executor_proto_rawDesc = "" +
 	"\tsignature\x18\x05 \x01(\fR\tsignature\x12&\n" +
 	"\x0foperator_set_id\x18\x06 \x01(\rR\roperatorSetId\x12/\n" +
 	"\x13reference_timestamp\x18\a \x01(\rR\x12referenceTimestamp\x12)\n" +
-	"\x10executor_address\x18\b \x01(\tR\x0fexecutorAddress\"\x83\x02\n" +
+	"\x10executor_address\x18\b \x01(\tR\x0fexecutorAddress\x12*\n" +
+	"\x11task_block_number\x18\t \x01(\x04R\x0ftaskBlockNumber\"\x83\x02\n" +
 	"\n" +
 	"TaskResult\x12\x17\n" +
 	"\atask_id\x18\x01 \x01(\tR\x06taskId\x12)\n" +

--- a/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
+++ b/ponos/internal/tests/certificateVerifier/certificateVerifier_integration_test.go
@@ -317,7 +317,6 @@ func Test_CertificateVerifier(t *testing.T) {
 	agg, err := aggregation.NewECDSATaskResultAggregator(
 		context.Background(),
 		taskId,
-		taskCreatedBlock,
 		1,
 		10_000,
 		taskInputData,

--- a/ponos/internal/tests/mailbox/mailbox_integration_test.go
+++ b/ponos/internal/tests/mailbox/mailbox_integration_test.go
@@ -401,7 +401,6 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 			resultAgg, err := aggregation.NewECDSATaskResultAggregator(
 				ctx,
 				task.TaskId,
-				task.L1ReferenceBlockNumber,
 				task.OperatorSetId,
 				6667,
 				task.Payload,

--- a/ponos/internal/tests/mailbox/mailbox_integration_test.go
+++ b/ponos/internal/tests/mailbox/mailbox_integration_test.go
@@ -369,7 +369,7 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 			operatorPeersWeight, err := opManager.GetExecutorPeersAndWeightsForBlock(
 				ctx,
 				task.ChainId,
-				task.BlockNumber,
+				task.SourceBlockNumber,
 				task.OperatorSetId,
 			)
 			if err != nil {
@@ -401,7 +401,7 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 			resultAgg, err := aggregation.NewECDSATaskResultAggregator(
 				ctx,
 				task.TaskId,
-				task.BlockNumber,
+				task.L1ReferenceBlockNumber,
 				task.OperatorSetId,
 				6667,
 				task.Payload,

--- a/ponos/internal/tests/performance/benchmark_test.go
+++ b/ponos/internal/tests/performance/benchmark_test.go
@@ -52,7 +52,7 @@ func BenchmarkAggregatorOperations(b *testing.B) {
 		fn   func(b *testing.B, store storage.AggregatorStore)
 	}{
 		{
-			name: "SaveTask",
+			name: "SavePendingTask",
 			fn:   benchmarkSaveTask,
 		},
 		{
@@ -92,14 +92,14 @@ func benchmarkSaveTask(b *testing.B, store storage.AggregatorStore) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		task := &types.Task{
-			TaskId:        fmt.Sprintf("bench-task-%d", i),
-			AVSAddress:    "0x123",
-			OperatorSetId: uint32(i),
-			BlockNumber:   uint64(i / 100),
-			ChainId:       config.ChainId(1),
-			Payload:       make([]byte, 256), // 256 bytes payload
+			TaskId:            fmt.Sprintf("bench-task-%d", i),
+			AVSAddress:        "0x123",
+			OperatorSetId:     uint32(i),
+			SourceBlockNumber: uint64(i / 100),
+			ChainId:           config.ChainId(1),
+			Payload:           make([]byte, 256), // 256 bytes payload
 		}
-		if err := store.SaveTask(ctx, task); err != nil {
+		if err := store.SavePendingTask(ctx, task); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -117,7 +117,7 @@ func benchmarkGetTask(b *testing.B, store storage.AggregatorStore) {
 			OperatorSetId: uint32(i),
 			ChainId:       config.ChainId(1),
 		}
-		if err := store.SaveTask(ctx, task); err != nil {
+		if err := store.SavePendingTask(ctx, task); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -143,7 +143,7 @@ func benchmarkUpdateTaskStatus(b *testing.B, store storage.AggregatorStore) {
 			OperatorSetId: uint32(i),
 			ChainId:       config.ChainId(1),
 		}
-		if err := store.SaveTask(ctx, task); err != nil {
+		if err := store.SavePendingTask(ctx, task); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -176,7 +176,7 @@ func benchmarkListPendingTasks(b *testing.B, store storage.AggregatorStore) {
 			OperatorSetId: uint32(i),
 			ChainId:       config.ChainId(1),
 		}
-		if err := store.SaveTask(ctx, task); err != nil {
+		if err := store.SavePendingTask(ctx, task); err != nil {
 			b.Fatal(err)
 		}
 
@@ -262,7 +262,7 @@ func benchmarkConcurrentMixedOps(b *testing.B, store storage.AggregatorStore, co
 			OperatorSetId: uint32(i),
 			ChainId:       config.ChainId(1),
 		}
-		if err := store.SaveTask(ctx, task); err != nil {
+		if err := store.SavePendingTask(ctx, task); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -287,7 +287,7 @@ func benchmarkConcurrentMixedOps(b *testing.B, store storage.AggregatorStore, co
 						OperatorSetId: uint32(i),
 						ChainId:       config.ChainId(1),
 					}
-					if err := store.SaveTask(ctx, task); err != nil {
+					if err := store.SavePendingTask(ctx, task); err != nil {
 						b.Error(err)
 					}
 				case 1: // Get existing task
@@ -470,7 +470,7 @@ func benchmarkMemoryWithTasks(b *testing.B, store storage.AggregatorStore, taskC
 			ChainId:       config.ChainId(1),
 			Payload:       make([]byte, 1024), // 1KB payload
 		}
-		if err := store.SaveTask(ctx, task); err != nil {
+		if err := store.SavePendingTask(ctx, task); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/ponos/internal/tests/performance/benchmark_test.go
+++ b/ponos/internal/tests/performance/benchmark_test.go
@@ -92,12 +92,13 @@ func benchmarkSaveTask(b *testing.B, store storage.AggregatorStore) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		task := &types.Task{
-			TaskId:            fmt.Sprintf("bench-task-%d", i),
-			AVSAddress:        "0x123",
-			OperatorSetId:     uint32(i),
-			SourceBlockNumber: uint64(i / 100),
-			ChainId:           config.ChainId(1),
-			Payload:           make([]byte, 256), // 256 bytes payload
+			TaskId:                 fmt.Sprintf("bench-task-%d", i),
+			AVSAddress:             "0x123",
+			OperatorSetId:          uint32(i),
+			SourceBlockNumber:      uint64(i / 100),
+			L1ReferenceBlockNumber: uint64(i / 100),
+			ChainId:                config.ChainId(1),
+			Payload:                make([]byte, 256), // 256 bytes payload
 		}
 		if err := store.SavePendingTask(ctx, task); err != nil {
 			b.Fatal(err)

--- a/ponos/internal/tests/persistence/aggregator_integration_test.go
+++ b/ponos/internal/tests/persistence/aggregator_integration_test.go
@@ -35,10 +35,10 @@ func TestAggregatorCrashRecovery(t *testing.T) {
 		ThresholdBips:       6700,
 		Payload:             []byte("test payload 1"),
 		ChainId:             chainId,
-		BlockNumber:         990,
+		SourceBlockNumber:   990,
 		BlockHash:           "0xhash1",
 	}
-	require.NoError(t, store.SaveTask(ctx, task1))
+	require.NoError(t, store.SavePendingTask(ctx, task1))
 	require.NoError(t, store.UpdateTaskStatus(ctx, "task-1", storage.TaskStatusProcessing))
 
 	deadline2 := time.Now().Add(2 * time.Hour)
@@ -51,10 +51,10 @@ func TestAggregatorCrashRecovery(t *testing.T) {
 		ThresholdBips:       6700,
 		Payload:             []byte("test payload 2"),
 		ChainId:             chainId,
-		BlockNumber:         995,
+		SourceBlockNumber:   995,
 		BlockHash:           "0xhash2",
 	}
-	require.NoError(t, store.SaveTask(ctx, task2))
+	require.NoError(t, store.SavePendingTask(ctx, task2))
 
 	// Save some configs
 	operatorConfig := &storage.OperatorSetTaskConfig{
@@ -119,12 +119,12 @@ func TestAggregatorTaskFlowWithPersistence(t *testing.T) {
 		ThresholdBips:       6700,
 		Payload:             []byte("test payload"),
 		ChainId:             config.ChainId(1),
-		BlockNumber:         1000,
+		SourceBlockNumber:   1000,
 		BlockHash:           "0xhash",
 	}
 
 	// Save task
-	require.NoError(t, store.SaveTask(ctx, task))
+	require.NoError(t, store.SavePendingTask(ctx, task))
 
 	// Update status through lifecycle
 	require.NoError(t, store.UpdateTaskStatus(ctx, task.TaskId, storage.TaskStatusProcessing))
@@ -171,10 +171,10 @@ func TestAggregatorConcurrentOperations(t *testing.T) {
 					ThresholdBips:       6700,
 					Payload:             []byte(fmt.Sprintf("payload-%d-%d", id, j)),
 					ChainId:             config.ChainId(1),
-					BlockNumber:         uint64(1000 + j),
+					SourceBlockNumber:   uint64(1000 + j),
 					BlockHash:           fmt.Sprintf("0xhash%d%d", id, j),
 				}
-				if err := store.SaveTask(ctx, task); err != nil {
+				if err := store.SavePendingTask(ctx, task); err != nil {
 					errors <- err
 				}
 			}

--- a/ponos/internal/tests/persistence/aggregator_integration_test.go
+++ b/ponos/internal/tests/persistence/aggregator_integration_test.go
@@ -27,32 +27,34 @@ func TestAggregatorCrashRecovery(t *testing.T) {
 	// Save some tasks
 	deadline1 := time.Now().Add(1 * time.Hour)
 	task1 := &types.Task{
-		TaskId:              "task-1",
-		AVSAddress:          "0xavs1",
-		OperatorSetId:       1,
-		CallbackAddr:        "0xcallback",
-		DeadlineUnixSeconds: &deadline1,
-		ThresholdBips:       6700,
-		Payload:             []byte("test payload 1"),
-		ChainId:             chainId,
-		SourceBlockNumber:   990,
-		BlockHash:           "0xhash1",
+		TaskId:                 "task-1",
+		AVSAddress:             "0xavs1",
+		OperatorSetId:          1,
+		CallbackAddr:           "0xcallback",
+		DeadlineUnixSeconds:    &deadline1,
+		ThresholdBips:          6700,
+		Payload:                []byte("test payload 1"),
+		ChainId:                chainId,
+		SourceBlockNumber:      990,
+		L1ReferenceBlockNumber: 990,
+		BlockHash:              "0xhash1",
 	}
 	require.NoError(t, store.SavePendingTask(ctx, task1))
 	require.NoError(t, store.UpdateTaskStatus(ctx, "task-1", storage.TaskStatusProcessing))
 
 	deadline2 := time.Now().Add(2 * time.Hour)
 	task2 := &types.Task{
-		TaskId:              "task-2",
-		AVSAddress:          "0xavs1",
-		OperatorSetId:       1,
-		CallbackAddr:        "0xcallback",
-		DeadlineUnixSeconds: &deadline2,
-		ThresholdBips:       6700,
-		Payload:             []byte("test payload 2"),
-		ChainId:             chainId,
-		SourceBlockNumber:   995,
-		BlockHash:           "0xhash2",
+		TaskId:                 "task-2",
+		AVSAddress:             "0xavs1",
+		OperatorSetId:          1,
+		CallbackAddr:           "0xcallback",
+		DeadlineUnixSeconds:    &deadline2,
+		ThresholdBips:          6700,
+		Payload:                []byte("test payload 2"),
+		ChainId:                chainId,
+		SourceBlockNumber:      995,
+		L1ReferenceBlockNumber: 995,
+		BlockHash:              "0xhash2",
 	}
 	require.NoError(t, store.SavePendingTask(ctx, task2))
 
@@ -111,16 +113,17 @@ func TestAggregatorTaskFlowWithPersistence(t *testing.T) {
 	// Test task lifecycle
 	deadline := time.Now().Add(1 * time.Hour)
 	task := &types.Task{
-		TaskId:              "task-flow-1",
-		AVSAddress:          "0xavs2",
-		OperatorSetId:       1,
-		CallbackAddr:        "0xcallback",
-		DeadlineUnixSeconds: &deadline,
-		ThresholdBips:       6700,
-		Payload:             []byte("test payload"),
-		ChainId:             config.ChainId(1),
-		SourceBlockNumber:   1000,
-		BlockHash:           "0xhash",
+		TaskId:                 "task-flow-1",
+		AVSAddress:             "0xavs2",
+		OperatorSetId:          1,
+		CallbackAddr:           "0xcallback",
+		DeadlineUnixSeconds:    &deadline,
+		ThresholdBips:          6700,
+		Payload:                []byte("test payload"),
+		ChainId:                config.ChainId(1),
+		SourceBlockNumber:      1000,
+		L1ReferenceBlockNumber: 1000,
+		BlockHash:              "0xhash",
 	}
 
 	// Save task
@@ -163,16 +166,17 @@ func TestAggregatorConcurrentOperations(t *testing.T) {
 			for j := 0; j < 100; j++ {
 				deadline := time.Now().Add(time.Hour)
 				task := &types.Task{
-					TaskId:              fmt.Sprintf("concurrent-task-%d-%d", id, j),
-					AVSAddress:          fmt.Sprintf("0xavs%d", id),
-					OperatorSetId:       uint32(id),
-					CallbackAddr:        "0xcallback",
-					DeadlineUnixSeconds: &deadline,
-					ThresholdBips:       6700,
-					Payload:             []byte(fmt.Sprintf("payload-%d-%d", id, j)),
-					ChainId:             config.ChainId(1),
-					SourceBlockNumber:   uint64(1000 + j),
-					BlockHash:           fmt.Sprintf("0xhash%d%d", id, j),
+					TaskId:                 fmt.Sprintf("concurrent-task-%d-%d", id, j),
+					AVSAddress:             fmt.Sprintf("0xavs%d", id),
+					OperatorSetId:          uint32(id),
+					CallbackAddr:           "0xcallback",
+					DeadlineUnixSeconds:    &deadline,
+					ThresholdBips:          6700,
+					Payload:                []byte(fmt.Sprintf("payload-%d-%d", id, j)),
+					ChainId:                config.ChainId(1),
+					SourceBlockNumber:      uint64(1000 + j),
+					L1ReferenceBlockNumber: uint64(1000 + j),
+					BlockHash:              fmt.Sprintf("0xhash%d%d", id, j),
 				}
 				if err := store.SavePendingTask(ctx, task); err != nil {
 					errors <- err

--- a/ponos/internal/tests/persistence/benchmark_test.go
+++ b/ponos/internal/tests/persistence/benchmark_test.go
@@ -34,16 +34,17 @@ func newSyncMapBaseline() *syncMapBaseline {
 func createTask(id string) *types.Task {
 	deadline := time.Now().Add(time.Hour)
 	return &types.Task{
-		TaskId:              id,
-		AVSAddress:          "0xavs1",
-		OperatorSetId:       1,
-		CallbackAddr:        "0xcallback",
-		DeadlineUnixSeconds: &deadline,
-		ThresholdBips:       6700,
-		Payload:             []byte(fmt.Sprintf("payload-%s", id)),
-		ChainId:             config.ChainId(1),
-		SourceBlockNumber:   1000,
-		BlockHash:           fmt.Sprintf("0xhash%s", id),
+		TaskId:                 id,
+		AVSAddress:             "0xavs1",
+		OperatorSetId:          1,
+		CallbackAddr:           "0xcallback",
+		DeadlineUnixSeconds:    &deadline,
+		ThresholdBips:          6700,
+		Payload:                []byte(fmt.Sprintf("payload-%s", id)),
+		ChainId:                config.ChainId(1),
+		SourceBlockNumber:      1000,
+		L1ReferenceBlockNumber: 1000,
+		BlockHash:              fmt.Sprintf("0xhash%s", id),
 	}
 }
 

--- a/ponos/internal/tests/production/production_test.go
+++ b/ponos/internal/tests/production/production_test.go
@@ -181,12 +181,13 @@ func TestProductionRecovery(t *testing.T) {
 		}
 
 		task := &types.Task{
-			TaskId:            fmt.Sprintf("prod-task-%d", i),
-			AVSAddress:        "0x123",
-			OperatorSetId:     uint32(i),
-			SourceBlockNumber: uint64(i / 10),
-			ChainId:           1,
-			Payload:           make([]byte, 1024), // 1KB payload
+			TaskId:                 fmt.Sprintf("prod-task-%d", i),
+			AVSAddress:             "0x123",
+			OperatorSetId:          uint32(i),
+			SourceBlockNumber:      uint64(i / 10),
+			L1ReferenceBlockNumber: uint64(i / 10),
+			ChainId:                1,
+			Payload:                make([]byte, 1024), // 1KB payload
 		}
 		require.NoError(t, store.SavePendingTask(ctx, task))
 
@@ -229,11 +230,12 @@ func TestProductionRecovery(t *testing.T) {
 	require.NoError(t, store2.SetLastProcessedBlock(ctx, chainId, lastBlock+1000))
 
 	newTask := &types.Task{
-		TaskId:            "post-recovery-task",
-		AVSAddress:        "0x123",
-		OperatorSetId:     uint32(numTasks),
-		SourceBlockNumber: lastBlock + 1000,
-		ChainId:           chainId,
+		TaskId:                 "post-recovery-task",
+		AVSAddress:             "0x123",
+		OperatorSetId:          uint32(numTasks),
+		SourceBlockNumber:      lastBlock + 1000,
+		L1ReferenceBlockNumber: lastBlock + 1000,
+		ChainId:                chainId,
 	}
 	require.NoError(t, store2.SavePendingTask(ctx, newTask))
 }
@@ -356,11 +358,12 @@ func TestProductionScale(t *testing.T) {
 			}
 
 			task := &types.Task{
-				TaskId:            fmt.Sprintf("chain%d-task-%d", c, i),
-				AVSAddress:        fmt.Sprintf("0xavs%d", c),
-				OperatorSetId:     uint32(i),
-				SourceBlockNumber: uint64(i / 100),
-				ChainId:           config.ChainId(c),
+				TaskId:                 fmt.Sprintf("chain%d-task-%d", c, i),
+				AVSAddress:             fmt.Sprintf("0xavs%d", c),
+				OperatorSetId:          uint32(i),
+				SourceBlockNumber:      uint64(i / 100),
+				L1ReferenceBlockNumber: uint64(i / 100),
+				ChainId:                config.ChainId(c),
 			}
 			require.NoError(t, store.SavePendingTask(ctx, task))
 		}

--- a/ponos/internal/tests/production/production_test.go
+++ b/ponos/internal/tests/production/production_test.go
@@ -181,14 +181,14 @@ func TestProductionRecovery(t *testing.T) {
 		}
 
 		task := &types.Task{
-			TaskId:        fmt.Sprintf("prod-task-%d", i),
-			AVSAddress:    "0x123",
-			OperatorSetId: uint32(i),
-			BlockNumber:   uint64(i / 10),
-			ChainId:       1,
-			Payload:       make([]byte, 1024), // 1KB payload
+			TaskId:            fmt.Sprintf("prod-task-%d", i),
+			AVSAddress:        "0x123",
+			OperatorSetId:     uint32(i),
+			SourceBlockNumber: uint64(i / 10),
+			ChainId:           1,
+			Payload:           make([]byte, 1024), // 1KB payload
 		}
-		require.NoError(t, store.SaveTask(ctx, task))
+		require.NoError(t, store.SavePendingTask(ctx, task))
 
 		// Update some tasks
 		if i > 0 && i%3 == 0 {
@@ -229,13 +229,13 @@ func TestProductionRecovery(t *testing.T) {
 	require.NoError(t, store2.SetLastProcessedBlock(ctx, chainId, lastBlock+1000))
 
 	newTask := &types.Task{
-		TaskId:        "post-recovery-task",
-		AVSAddress:    "0x123",
-		OperatorSetId: uint32(numTasks),
-		BlockNumber:   lastBlock + 1000,
-		ChainId:       chainId,
+		TaskId:            "post-recovery-task",
+		AVSAddress:        "0x123",
+		OperatorSetId:     uint32(numTasks),
+		SourceBlockNumber: lastBlock + 1000,
+		ChainId:           chainId,
 	}
-	require.NoError(t, store2.SaveTask(ctx, newTask))
+	require.NoError(t, store2.SavePendingTask(ctx, newTask))
 }
 
 // TestProductionMetrics validates metrics and monitoring
@@ -261,10 +261,10 @@ func TestProductionMetrics(t *testing.T) {
 			ChainId:       config.ChainId(1),
 		}
 
-		// SaveTask
+		// SavePendingTask
 		start := time.Now()
-		err := store.SaveTask(ctx, task)
-		timings["SaveTask"] = append(timings["SaveTask"], time.Since(start))
+		err := store.SavePendingTask(ctx, task)
+		timings["SavePendingTask"] = append(timings["SavePendingTask"], time.Since(start))
 		require.NoError(t, err)
 
 		// GetTask
@@ -305,7 +305,7 @@ func TestProductionMetrics(t *testing.T) {
 		// Production SLAs
 		var maxAllowed time.Duration
 		switch op {
-		case "SaveTask", "GetTask", "UpdateTaskStatus":
+		case "SavePendingTask", "GetTask", "UpdateTaskStatus":
 			maxAllowed = 10 * time.Millisecond
 		case "ListPendingTasks":
 			maxAllowed = 100 * time.Millisecond
@@ -356,13 +356,13 @@ func TestProductionScale(t *testing.T) {
 			}
 
 			task := &types.Task{
-				TaskId:        fmt.Sprintf("chain%d-task-%d", c, i),
-				AVSAddress:    fmt.Sprintf("0xavs%d", c),
-				OperatorSetId: uint32(i),
-				BlockNumber:   uint64(i / 100),
-				ChainId:       config.ChainId(c),
+				TaskId:            fmt.Sprintf("chain%d-task-%d", c, i),
+				AVSAddress:        fmt.Sprintf("0xavs%d", c),
+				OperatorSetId:     uint32(i),
+				SourceBlockNumber: uint64(i / 100),
+				ChainId:           config.ChainId(c),
 			}
-			require.NoError(t, store.SaveTask(ctx, task))
+			require.NoError(t, store.SavePendingTask(ctx, task))
 		}
 	}
 

--- a/ponos/internal/tests/stability/stability_test.go
+++ b/ponos/internal/tests/stability/stability_test.go
@@ -224,15 +224,15 @@ func simulateAggregator(ctx context.Context, t *testing.T, store storage.Aggrega
 			// Create random tasks
 			if rand.Intn(10) < 3 { // 30% chance
 				task := &types.Task{
-					TaskId:        fmt.Sprintf("task-%d", taskCounter),
-					AVSAddress:    "0x123",
-					OperatorSetId: uint32(taskCounter),
-					BlockNumber:   blockNum,
-					ChainId:       chainId,
+					TaskId:            fmt.Sprintf("task-%d", taskCounter),
+					AVSAddress:        "0x123",
+					OperatorSetId:     uint32(taskCounter),
+					SourceBlockNumber: blockNum,
+					ChainId:           chainId,
 				}
 				taskCounter++
 
-				err = store.SaveTask(ctx, task)
+				err = store.SavePendingTask(ctx, task)
 				if err != nil {
 					t.Logf("Error saving task: %v", err)
 					atomic.AddInt64(&stats.errors, 1)
@@ -438,7 +438,7 @@ func TestConcurrentLoad(t *testing.T) {
 								AVSAddress:    "0x123",
 								OperatorSetId: uint32(j),
 							}
-							if err := store.SaveTask(ctx, task); err != nil {
+							if err := store.SavePendingTask(ctx, task); err != nil {
 								errors <- err
 							}
 						case 1: // Update block
@@ -526,7 +526,7 @@ func TestMemoryLeaks(t *testing.T) {
 		}
 
 		// Create and delete tasks
-		require.NoError(t, store.SaveTask(ctx, task))
+		require.NoError(t, store.SavePendingTask(ctx, task))
 		require.NoError(t, store.UpdateTaskStatus(ctx, task.TaskId, storage.TaskStatusProcessing))
 		require.NoError(t, store.UpdateTaskStatus(ctx, task.TaskId, storage.TaskStatusCompleted))
 

--- a/ponos/internal/tests/upgrade/upgrade_test.go
+++ b/ponos/internal/tests/upgrade/upgrade_test.go
@@ -82,11 +82,12 @@ func TestRollingUpgrade(t *testing.T) {
 			require.NoError(t, aggStore1.SetLastProcessedBlock(ctx, chainId, 1000))
 
 			task := &types.Task{
-				TaskId:            "upgrade-task-1",
-				AVSAddress:        "0x123",
-				OperatorSetId:     1,
-				SourceBlockNumber: 1000,
-				ChainId:           config.ChainId(1),
+				TaskId:                 "upgrade-task-1",
+				AVSAddress:             "0x123",
+				OperatorSetId:          1,
+				SourceBlockNumber:      1000,
+				L1ReferenceBlockNumber: 1000,
+				ChainId:                config.ChainId(1),
 			}
 			require.NoError(t, aggStore1.SavePendingTask(ctx, task))
 
@@ -159,11 +160,12 @@ func TestRollingUpgrade(t *testing.T) {
 			require.NoError(t, aggStore2.SetLastProcessedBlock(ctx, chainId, 2000))
 
 			newTask := &types.Task{
-				TaskId:            "upgrade-task-2",
-				AVSAddress:        "0x123",
-				OperatorSetId:     2,
-				SourceBlockNumber: 2000,
-				ChainId:           config.ChainId(1),
+				TaskId:                 "upgrade-task-2",
+				AVSAddress:             "0x123",
+				OperatorSetId:          2,
+				SourceBlockNumber:      2000,
+				L1ReferenceBlockNumber: 2000,
+				ChainId:                config.ChainId(1),
 			}
 			require.NoError(t, aggStore2.SavePendingTask(ctx, newTask))
 		})
@@ -182,9 +184,9 @@ func TestStorageMigration(t *testing.T) {
 	require.NoError(t, memStore.SetLastProcessedBlock(ctx, chainId, 5000))
 
 	tasks := []*types.Task{
-		{TaskId: "task-1", AVSAddress: "0x123", OperatorSetId: 1, SourceBlockNumber: 4990, ChainId: chainId},
-		{TaskId: "task-2", AVSAddress: "0x123", OperatorSetId: 2, SourceBlockNumber: 4995, ChainId: chainId},
-		{TaskId: "task-3", AVSAddress: "0x123", OperatorSetId: 3, SourceBlockNumber: 5000, ChainId: chainId},
+		{TaskId: "task-1", AVSAddress: "0x123", OperatorSetId: 1, SourceBlockNumber: 4990, L1ReferenceBlockNumber: 4990, ChainId: chainId},
+		{TaskId: "task-2", AVSAddress: "0x123", OperatorSetId: 2, SourceBlockNumber: 4995, L1ReferenceBlockNumber: 4995, ChainId: chainId},
+		{TaskId: "task-3", AVSAddress: "0x123", OperatorSetId: 3, SourceBlockNumber: 5000, L1ReferenceBlockNumber: 5000, ChainId: chainId},
 	}
 
 	for _, task := range tasks {
@@ -266,12 +268,13 @@ func TestBackwardCompatibility(t *testing.T) {
 	require.NoError(t, store.SetLastProcessedBlock(ctx, chainId, 1000))
 
 	task := &types.Task{
-		TaskId:            "compat-task",
-		AVSAddress:        "0x123",
-		OperatorSetId:     1,
-		SourceBlockNumber: 1000,
-		ChainId:           chainId,
-		Payload:           []byte("test payload"),
+		TaskId:                 "compat-task",
+		AVSAddress:             "0x123",
+		OperatorSetId:          1,
+		SourceBlockNumber:      1000,
+		L1ReferenceBlockNumber: 1000,
+		ChainId:                chainId,
+		Payload:                []byte("test payload"),
 	}
 	require.NoError(t, store.SavePendingTask(ctx, task))
 
@@ -350,11 +353,12 @@ func TestUpgradeUnderLoad(t *testing.T) {
 				// Write operations
 				_ = store1.SetLastProcessedBlock(ctx, chainId, blockNum)
 				task := &types.Task{
-					TaskId:            fmt.Sprintf("load-task-%d", taskId),
-					AVSAddress:        "0x123",
-					OperatorSetId:     uint32(taskId),
-					SourceBlockNumber: blockNum,
-					ChainId:           chainId,
+					TaskId:                 fmt.Sprintf("load-task-%d", taskId),
+					AVSAddress:             "0x123",
+					OperatorSetId:          uint32(taskId),
+					SourceBlockNumber:      blockNum,
+					L1ReferenceBlockNumber: blockNum,
+					ChainId:                chainId,
 				}
 				_ = store1.SavePendingTask(ctx, task)
 
@@ -394,11 +398,12 @@ func TestUpgradeUnderLoad(t *testing.T) {
 	require.NoError(t, store2.SetLastProcessedBlock(ctx, chainId, lastBlock2+100))
 
 	newTask := &types.Task{
-		TaskId:            "post-upgrade-task",
-		AVSAddress:        "0x123",
-		OperatorSetId:     9999,
-		SourceBlockNumber: lastBlock2 + 100,
-		ChainId:           chainId,
+		TaskId:                 "post-upgrade-task",
+		AVSAddress:             "0x123",
+		OperatorSetId:          9999,
+		SourceBlockNumber:      lastBlock2 + 100,
+		L1ReferenceBlockNumber: lastBlock2 + 100,
+		ChainId:                chainId,
 	}
 	require.NoError(t, store2.SavePendingTask(ctx, newTask))
 

--- a/ponos/internal/tests/upgrade/upgrade_test.go
+++ b/ponos/internal/tests/upgrade/upgrade_test.go
@@ -82,13 +82,13 @@ func TestRollingUpgrade(t *testing.T) {
 			require.NoError(t, aggStore1.SetLastProcessedBlock(ctx, chainId, 1000))
 
 			task := &types.Task{
-				TaskId:        "upgrade-task-1",
-				AVSAddress:    "0x123",
-				OperatorSetId: 1,
-				BlockNumber:   1000,
-				ChainId:       config.ChainId(1),
+				TaskId:            "upgrade-task-1",
+				AVSAddress:        "0x123",
+				OperatorSetId:     1,
+				SourceBlockNumber: 1000,
+				ChainId:           config.ChainId(1),
 			}
-			require.NoError(t, aggStore1.SaveTask(ctx, task))
+			require.NoError(t, aggStore1.SavePendingTask(ctx, task))
 
 			// Populate executor state
 			performer := &executorStorage.PerformerState{
@@ -159,13 +159,13 @@ func TestRollingUpgrade(t *testing.T) {
 			require.NoError(t, aggStore2.SetLastProcessedBlock(ctx, chainId, 2000))
 
 			newTask := &types.Task{
-				TaskId:        "upgrade-task-2",
-				AVSAddress:    "0x123",
-				OperatorSetId: 2,
-				BlockNumber:   2000,
-				ChainId:       config.ChainId(1),
+				TaskId:            "upgrade-task-2",
+				AVSAddress:        "0x123",
+				OperatorSetId:     2,
+				SourceBlockNumber: 2000,
+				ChainId:           config.ChainId(1),
 			}
-			require.NoError(t, aggStore2.SaveTask(ctx, newTask))
+			require.NoError(t, aggStore2.SavePendingTask(ctx, newTask))
 		})
 	}
 }
@@ -182,13 +182,13 @@ func TestStorageMigration(t *testing.T) {
 	require.NoError(t, memStore.SetLastProcessedBlock(ctx, chainId, 5000))
 
 	tasks := []*types.Task{
-		{TaskId: "task-1", AVSAddress: "0x123", OperatorSetId: 1, BlockNumber: 4990, ChainId: chainId},
-		{TaskId: "task-2", AVSAddress: "0x123", OperatorSetId: 2, BlockNumber: 4995, ChainId: chainId},
-		{TaskId: "task-3", AVSAddress: "0x123", OperatorSetId: 3, BlockNumber: 5000, ChainId: chainId},
+		{TaskId: "task-1", AVSAddress: "0x123", OperatorSetId: 1, SourceBlockNumber: 4990, ChainId: chainId},
+		{TaskId: "task-2", AVSAddress: "0x123", OperatorSetId: 2, SourceBlockNumber: 4995, ChainId: chainId},
+		{TaskId: "task-3", AVSAddress: "0x123", OperatorSetId: 3, SourceBlockNumber: 5000, ChainId: chainId},
 	}
 
 	for _, task := range tasks {
-		require.NoError(t, memStore.SaveTask(ctx, task))
+		require.NoError(t, memStore.SavePendingTask(ctx, task))
 	}
 	// Proper status transitions: pending -> processing -> completed
 	require.NoError(t, memStore.UpdateTaskStatus(ctx, "task-1", storage.TaskStatusProcessing))
@@ -211,7 +211,7 @@ func TestStorageMigration(t *testing.T) {
 	// Migrate all tasks (both pending and non-pending)
 	for _, task := range tasks {
 		if loadedTask, err := memStore.GetTask(ctx, task.TaskId); err == nil {
-			require.NoError(t, badgerStore.SaveTask(ctx, loadedTask))
+			require.NoError(t, badgerStore.SavePendingTask(ctx, loadedTask))
 			// Migrate status - need proper transitions
 			if task.TaskId == "task-1" {
 				// task-1 was already transitioned to completed in memory store
@@ -266,14 +266,14 @@ func TestBackwardCompatibility(t *testing.T) {
 	require.NoError(t, store.SetLastProcessedBlock(ctx, chainId, 1000))
 
 	task := &types.Task{
-		TaskId:        "compat-task",
-		AVSAddress:    "0x123",
-		OperatorSetId: 1,
-		BlockNumber:   1000,
-		ChainId:       chainId,
-		Payload:       []byte("test payload"),
+		TaskId:            "compat-task",
+		AVSAddress:        "0x123",
+		OperatorSetId:     1,
+		SourceBlockNumber: 1000,
+		ChainId:           chainId,
+		Payload:           []byte("test payload"),
 	}
-	require.NoError(t, store.SaveTask(ctx, task))
+	require.NoError(t, store.SavePendingTask(ctx, task))
 
 	opConfig := &storage.OperatorSetTaskConfig{
 		TaskSLA:   3600,
@@ -350,13 +350,13 @@ func TestUpgradeUnderLoad(t *testing.T) {
 				// Write operations
 				_ = store1.SetLastProcessedBlock(ctx, chainId, blockNum)
 				task := &types.Task{
-					TaskId:        fmt.Sprintf("load-task-%d", taskId),
-					AVSAddress:    "0x123",
-					OperatorSetId: uint32(taskId),
-					BlockNumber:   blockNum,
-					ChainId:       chainId,
+					TaskId:            fmt.Sprintf("load-task-%d", taskId),
+					AVSAddress:        "0x123",
+					OperatorSetId:     uint32(taskId),
+					SourceBlockNumber: blockNum,
+					ChainId:           chainId,
 				}
-				_ = store1.SaveTask(ctx, task)
+				_ = store1.SavePendingTask(ctx, task)
 
 				blockNum++
 				taskId++
@@ -394,13 +394,13 @@ func TestUpgradeUnderLoad(t *testing.T) {
 	require.NoError(t, store2.SetLastProcessedBlock(ctx, chainId, lastBlock2+100))
 
 	newTask := &types.Task{
-		TaskId:        "post-upgrade-task",
-		AVSAddress:    "0x123",
-		OperatorSetId: 9999,
-		BlockNumber:   lastBlock2 + 100,
-		ChainId:       chainId,
+		TaskId:            "post-upgrade-task",
+		AVSAddress:        "0x123",
+		OperatorSetId:     9999,
+		SourceBlockNumber: lastBlock2 + 100,
+		ChainId:           chainId,
 	}
-	require.NoError(t, store2.SaveTask(ctx, newTask))
+	require.NoError(t, store2.SavePendingTask(ctx, newTask))
 
 	// Verify task saved
 	loadedTask, err := store2.GetTask(ctx, "post-upgrade-task")

--- a/ponos/pkg/aggregator/avsExecutionManager/avsExecutionManager.go
+++ b/ponos/pkg/aggregator/avsExecutionManager/avsExecutionManager.go
@@ -415,6 +415,7 @@ func (em *AvsExecutionManager) handleTask(ctx context.Context, task *types.Task)
 	operatorPeersWeight, err := em.operatorManager.GetExecutorPeersAndWeightsForBlock(
 		ctx,
 		task.ChainId,
+		// This must be source block number so this method can translate to reference block.
 		task.SourceBlockNumber,
 		task.OperatorSetId,
 	)

--- a/ponos/pkg/aggregator/avsExecutionManager/avsExecutionManager.go
+++ b/ponos/pkg/aggregator/avsExecutionManager/avsExecutionManager.go
@@ -570,13 +570,13 @@ func (em *AvsExecutionManager) processBN254Task(
 		em.inflightTasks.Delete(task.TaskId)
 		return err
 	case <-ctx.Done():
-		switch ctx.Err() {
-		case context.Canceled:
+		switch err := ctx.Err(); {
+		case errors.Is(err, context.Canceled):
 			em.logger.Sugar().Errorw("task session context done",
 				zap.String("taskId", task.TaskId),
 				zap.Error(ctx.Err()),
 			)
-		case context.DeadlineExceeded:
+		case errors.Is(err, context.DeadlineExceeded):
 			em.logger.Sugar().Errorw("task session context deadline exceeded",
 				zap.String("taskId", task.TaskId),
 				zap.Error(ctx.Err()),

--- a/ponos/pkg/aggregator/storage/badger/badger.go
+++ b/ponos/pkg/aggregator/storage/badger/badger.go
@@ -160,7 +160,7 @@ func (s *BadgerAggregatorStore) SetLastProcessedBlock(ctx context.Context, chain
 }
 
 // SaveTask stores a task
-func (s *BadgerAggregatorStore) SaveTask(ctx context.Context, task *types.Task) error {
+func (s *BadgerAggregatorStore) SavePendingTask(ctx context.Context, task *types.Task) error {
 	s.mu.RLock()
 	if s.closed {
 		s.mu.RUnlock()

--- a/ponos/pkg/aggregator/storage/badger/badger_test.go
+++ b/ponos/pkg/aggregator/storage/badger/badger_test.go
@@ -58,14 +58,14 @@ func TestBadgerAggregatorStore_Persistence(t *testing.T) {
 			AVSAddress:          "0xAVS1",
 			Payload:             []byte("test payload"),
 			ChainId:             config.ChainId(1),
-			BlockNumber:         12345,
+			SourceBlockNumber:   12345,
 			OperatorSetId:       1,
 			CallbackAddr:        "0xcallback123",
 			ThresholdBips:       5000,
 			DeadlineUnixSeconds: &deadline,
 			BlockHash:           "0xblockhash123",
 		}
-		err = store.SaveTask(ctx, task)
+		err = store.SavePendingTask(ctx, task)
 		require.NoError(t, err)
 
 		// Set last processed block
@@ -114,14 +114,14 @@ func TestBadgerAggregatorStore_InMemory(t *testing.T) {
 		AVSAddress:          "0xAVS1",
 		Payload:             []byte("test payload"),
 		ChainId:             config.ChainId(1),
-		BlockNumber:         12345,
+		SourceBlockNumber:   12345,
 		OperatorSetId:       1,
 		CallbackAddr:        "0xcallback123",
 		ThresholdBips:       5000,
 		DeadlineUnixSeconds: &deadline,
 		BlockHash:           "0xblockhash123",
 	}
-	err = store.SaveTask(ctx, task)
+	err = store.SavePendingTask(ctx, task)
 	require.NoError(t, err)
 
 	retrieved, err := store.GetTask(ctx, "task-1")
@@ -154,14 +154,14 @@ func TestBadgerAggregatorStore_LargeDataSet(t *testing.T) {
 			AVSAddress:          "0xAVS1",
 			Payload:             []byte("test payload"),
 			ChainId:             config.ChainId(1),
-			BlockNumber:         12345,
+			SourceBlockNumber:   12345,
 			OperatorSetId:       1,
 			CallbackAddr:        "0xcallback123",
 			ThresholdBips:       5000,
 			DeadlineUnixSeconds: &deadline,
 			BlockHash:           "0xblockhash123",
 		}
-		err := store.SaveTask(ctx, task)
+		err := store.SavePendingTask(ctx, task)
 		require.NoError(t, err)
 	}
 
@@ -197,7 +197,7 @@ func BenchmarkBadgerAggregatorStore(b *testing.B) {
 
 	ctx := context.Background()
 
-	b.Run("SaveTask", func(b *testing.B) {
+	b.Run("SavePendingTask", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			deadline := time.Now().Add(time.Hour)
@@ -206,14 +206,14 @@ func BenchmarkBadgerAggregatorStore(b *testing.B) {
 				AVSAddress:          "0xAVS1",
 				Payload:             []byte("test payload"),
 				ChainId:             config.ChainId(1),
-				BlockNumber:         12345,
+				SourceBlockNumber:   12345,
 				OperatorSetId:       1,
 				CallbackAddr:        "0xcallback123",
 				ThresholdBips:       5000,
 				DeadlineUnixSeconds: &deadline,
 				BlockHash:           "0xblockhash123",
 			}
-			_ = store.SaveTask(ctx, task)
+			_ = store.SavePendingTask(ctx, task)
 		}
 	})
 
@@ -226,14 +226,14 @@ func BenchmarkBadgerAggregatorStore(b *testing.B) {
 				AVSAddress:          "0xAVS1",
 				Payload:             []byte("test payload"),
 				ChainId:             config.ChainId(1),
-				BlockNumber:         12345,
+				SourceBlockNumber:   12345,
 				OperatorSetId:       1,
 				CallbackAddr:        "0xcallback123",
 				ThresholdBips:       5000,
 				DeadlineUnixSeconds: &deadline,
 				BlockHash:           "0xblockhash123",
 			}
-			_ = store.SaveTask(ctx, task)
+			_ = store.SavePendingTask(ctx, task)
 		}
 
 		b.ResetTimer()

--- a/ponos/pkg/aggregator/storage/badger/badger_test.go
+++ b/ponos/pkg/aggregator/storage/badger/badger_test.go
@@ -110,16 +110,17 @@ func TestBadgerAggregatorStore_InMemory(t *testing.T) {
 	ctx := context.Background()
 	deadline := time.Now().Add(time.Hour)
 	task := &types.Task{
-		TaskId:              "task-1",
-		AVSAddress:          "0xAVS1",
-		Payload:             []byte("test payload"),
-		ChainId:             config.ChainId(1),
-		SourceBlockNumber:   12345,
-		OperatorSetId:       1,
-		CallbackAddr:        "0xcallback123",
-		ThresholdBips:       5000,
-		DeadlineUnixSeconds: &deadline,
-		BlockHash:           "0xblockhash123",
+		TaskId:                 "task-1",
+		AVSAddress:             "0xAVS1",
+		Payload:                []byte("test payload"),
+		ChainId:                config.ChainId(1),
+		SourceBlockNumber:      12345,
+		L1ReferenceBlockNumber: 12345,
+		OperatorSetId:          1,
+		CallbackAddr:           "0xcallback123",
+		ThresholdBips:          5000,
+		DeadlineUnixSeconds:    &deadline,
+		BlockHash:              "0xblockhash123",
 	}
 	err = store.SavePendingTask(ctx, task)
 	require.NoError(t, err)
@@ -150,16 +151,17 @@ func TestBadgerAggregatorStore_LargeDataSet(t *testing.T) {
 	for i := 0; i < numTasks; i++ {
 		deadline := time.Now().Add(time.Hour)
 		task := &types.Task{
-			TaskId:              fmt.Sprintf("task-%d", i),
-			AVSAddress:          "0xAVS1",
-			Payload:             []byte("test payload"),
-			ChainId:             config.ChainId(1),
-			SourceBlockNumber:   12345,
-			OperatorSetId:       1,
-			CallbackAddr:        "0xcallback123",
-			ThresholdBips:       5000,
-			DeadlineUnixSeconds: &deadline,
-			BlockHash:           "0xblockhash123",
+			TaskId:                 fmt.Sprintf("task-%d", i),
+			AVSAddress:             "0xAVS1",
+			Payload:                []byte("test payload"),
+			ChainId:                config.ChainId(1),
+			SourceBlockNumber:      12345,
+			L1ReferenceBlockNumber: 12345,
+			OperatorSetId:          1,
+			CallbackAddr:           "0xcallback123",
+			ThresholdBips:          5000,
+			DeadlineUnixSeconds:    &deadline,
+			BlockHash:              "0xblockhash123",
 		}
 		err := store.SavePendingTask(ctx, task)
 		require.NoError(t, err)
@@ -202,16 +204,17 @@ func BenchmarkBadgerAggregatorStore(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			deadline := time.Now().Add(time.Hour)
 			task := &types.Task{
-				TaskId:              fmt.Sprintf("task-bench-%d", i),
-				AVSAddress:          "0xAVS1",
-				Payload:             []byte("test payload"),
-				ChainId:             config.ChainId(1),
-				SourceBlockNumber:   12345,
-				OperatorSetId:       1,
-				CallbackAddr:        "0xcallback123",
-				ThresholdBips:       5000,
-				DeadlineUnixSeconds: &deadline,
-				BlockHash:           "0xblockhash123",
+				TaskId:                 fmt.Sprintf("task-bench-%d", i),
+				AVSAddress:             "0xAVS1",
+				Payload:                []byte("test payload"),
+				ChainId:                config.ChainId(1),
+				SourceBlockNumber:      12345,
+				L1ReferenceBlockNumber: 12345,
+				OperatorSetId:          1,
+				CallbackAddr:           "0xcallback123",
+				ThresholdBips:          5000,
+				DeadlineUnixSeconds:    &deadline,
+				BlockHash:              "0xblockhash123",
 			}
 			_ = store.SavePendingTask(ctx, task)
 		}
@@ -222,16 +225,17 @@ func BenchmarkBadgerAggregatorStore(b *testing.B) {
 		for i := 0; i < 100; i++ {
 			deadline := time.Now().Add(time.Hour)
 			task := &types.Task{
-				TaskId:              fmt.Sprintf("task-get-%d", i),
-				AVSAddress:          "0xAVS1",
-				Payload:             []byte("test payload"),
-				ChainId:             config.ChainId(1),
-				SourceBlockNumber:   12345,
-				OperatorSetId:       1,
-				CallbackAddr:        "0xcallback123",
-				ThresholdBips:       5000,
-				DeadlineUnixSeconds: &deadline,
-				BlockHash:           "0xblockhash123",
+				TaskId:                 fmt.Sprintf("task-get-%d", i),
+				AVSAddress:             "0xAVS1",
+				Payload:                []byte("test payload"),
+				ChainId:                config.ChainId(1),
+				SourceBlockNumber:      12345,
+				L1ReferenceBlockNumber: 12345,
+				OperatorSetId:          1,
+				CallbackAddr:           "0xcallback123",
+				ThresholdBips:          5000,
+				DeadlineUnixSeconds:    &deadline,
+				BlockHash:              "0xblockhash123",
 			}
 			_ = store.SavePendingTask(ctx, task)
 		}

--- a/ponos/pkg/aggregator/storage/memory/memory.go
+++ b/ponos/pkg/aggregator/storage/memory/memory.go
@@ -63,7 +63,7 @@ func (s *InMemoryAggregatorStore) SetLastProcessedBlock(ctx context.Context, cha
 }
 
 // SaveTask saves a task to storage
-func (s *InMemoryAggregatorStore) SaveTask(ctx context.Context, task *types.Task) error {
+func (s *InMemoryAggregatorStore) SavePendingTask(ctx context.Context, task *types.Task) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/ponos/pkg/aggregator/storage/storage.go
+++ b/ponos/pkg/aggregator/storage/storage.go
@@ -15,7 +15,7 @@ type AggregatorStore interface {
 	SetLastProcessedBlock(ctx context.Context, chainId config.ChainId, blockNum uint64) error
 
 	// Task management
-	SaveTask(ctx context.Context, task *types.Task) error
+	SavePendingTask(ctx context.Context, task *types.Task) error
 	GetTask(ctx context.Context, taskId string) (*types.Task, error)
 	ListPendingTasks(ctx context.Context) ([]*types.Task, error)
 	ListPendingTasksForAVS(ctx context.Context, avsAddress string) ([]*types.Task, error)

--- a/ponos/pkg/aggregator/storage/test_suite.go
+++ b/ponos/pkg/aggregator/storage/test_suite.go
@@ -85,7 +85,7 @@ func (s *TestSuite) testTaskManagement(t *testing.T) {
 		AVSAddress:          "0xavs123",
 		Payload:             []byte("test payload"),
 		ChainId:             config.ChainId(1),
-		BlockNumber:         12345,
+		SourceBlockNumber:   12345,
 		OperatorSetId:       1,
 		CallbackAddr:        "0xcallback123",
 		ThresholdBips:       5000,
@@ -98,7 +98,7 @@ func (s *TestSuite) testTaskManagement(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 
 	// Test saving and getting task
-	err = store.SaveTask(ctx, task)
+	err = store.SavePendingTask(ctx, task)
 	require.NoError(t, err)
 
 	retrieved, err := store.GetTask(ctx, task.TaskId)
@@ -125,14 +125,14 @@ func (s *TestSuite) testTaskManagement(t *testing.T) {
 		AVSAddress:          "0xavs456",
 		Payload:             []byte("test payload 2"),
 		ChainId:             config.ChainId(1),
-		BlockNumber:         12346,
+		SourceBlockNumber:   12346,
 		OperatorSetId:       1,
 		CallbackAddr:        "0xcallback456",
 		ThresholdBips:       5000,
 		DeadlineUnixSeconds: &deadline,
 		BlockHash:           "0xblockhash456",
 	}
-	err = store.SaveTask(ctx, task2)
+	err = store.SavePendingTask(ctx, task2)
 	require.NoError(t, err)
 
 	// Test listing all pending tasks (should have 2)

--- a/ponos/pkg/aggregator/storage/test_suite.go
+++ b/ponos/pkg/aggregator/storage/test_suite.go
@@ -81,16 +81,17 @@ func (s *TestSuite) testTaskManagement(t *testing.T) {
 	// Create test task
 	deadline := time.Now().Add(time.Hour)
 	task := &types.Task{
-		TaskId:              "task-123",
-		AVSAddress:          "0xavs123",
-		Payload:             []byte("test payload"),
-		ChainId:             config.ChainId(1),
-		SourceBlockNumber:   12345,
-		OperatorSetId:       1,
-		CallbackAddr:        "0xcallback123",
-		ThresholdBips:       5000,
-		DeadlineUnixSeconds: &deadline,
-		BlockHash:           "0xblockhash123",
+		TaskId:                 "task-123",
+		AVSAddress:             "0xavs123",
+		Payload:                []byte("test payload"),
+		ChainId:                config.ChainId(1),
+		SourceBlockNumber:      12345,
+		L1ReferenceBlockNumber: 12345,
+		OperatorSetId:          1,
+		CallbackAddr:           "0xcallback123",
+		ThresholdBips:          5000,
+		DeadlineUnixSeconds:    &deadline,
+		BlockHash:              "0xblockhash123",
 	}
 
 	// Test getting non-existent task
@@ -121,16 +122,17 @@ func (s *TestSuite) testTaskManagement(t *testing.T) {
 
 	// Create another task for a different AVS
 	task2 := &types.Task{
-		TaskId:              "task-456",
-		AVSAddress:          "0xavs456",
-		Payload:             []byte("test payload 2"),
-		ChainId:             config.ChainId(1),
-		SourceBlockNumber:   12346,
-		OperatorSetId:       1,
-		CallbackAddr:        "0xcallback456",
-		ThresholdBips:       5000,
-		DeadlineUnixSeconds: &deadline,
-		BlockHash:           "0xblockhash456",
+		TaskId:                 "task-456",
+		AVSAddress:             "0xavs456",
+		Payload:                []byte("test payload 2"),
+		ChainId:                config.ChainId(1),
+		SourceBlockNumber:      12346,
+		L1ReferenceBlockNumber: 12345,
+		OperatorSetId:          1,
+		CallbackAddr:           "0xcallback456",
+		ThresholdBips:          5000,
+		DeadlineUnixSeconds:    &deadline,
+		BlockHash:              "0xblockhash456",
 	}
 	err = store.SavePendingTask(ctx, task2)
 	require.NoError(t, err)

--- a/ponos/pkg/clients/ethereum/client_test.go
+++ b/ponos/pkg/clients/ethereum/client_test.go
@@ -41,7 +41,7 @@ func Test_EthereumClient(t *testing.T) {
 				assert.NotEmpty(t, log.Address)
 				assert.NotEmpty(t, log.BlockHash)
 				assert.NotEmpty(t, log.TransactionHash)
-				// BlockNumber should be within the requested range
+				// SourceBlockNumber should be within the requested range
 				blockNum := log.BlockNumber.Value()
 				assert.True(t, blockNum >= fromBlock && blockNum <= toBlock)
 			}

--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -35,6 +35,7 @@ import (
 )
 
 type ContractCaller struct {
+	l1ChainId          *big.Int
 	taskMailbox        *ITaskMailbox.ITaskMailbox
 	allocationManager  *IAllocationManager.IAllocationManager
 	delegationManager  *IDelegationManager.IDelegationManager
@@ -114,6 +115,7 @@ func NewContractCaller(
 	}
 
 	return &ContractCaller{
+		l1ChainId:          chainId,
 		taskMailbox:        taskMailbox,
 		allocationManager:  allocationManager,
 		keyRegistrar:       keyRegistrar,

--- a/ponos/pkg/contractCaller/caller/caller.go
+++ b/ponos/pkg/contractCaller/caller/caller.go
@@ -35,7 +35,6 @@ import (
 )
 
 type ContractCaller struct {
-	l1ChainId          *big.Int
 	taskMailbox        *ITaskMailbox.ITaskMailbox
 	allocationManager  *IAllocationManager.IAllocationManager
 	delegationManager  *IDelegationManager.IDelegationManager
@@ -115,7 +114,6 @@ func NewContractCaller(
 	}
 
 	return &ContractCaller{
-		l1ChainId:          chainId,
 		taskMailbox:        taskMailbox,
 		allocationManager:  allocationManager,
 		keyRegistrar:       keyRegistrar,

--- a/ponos/pkg/contractCaller/contractCaller.go
+++ b/ponos/pkg/contractCaller/contractCaller.go
@@ -76,13 +76,13 @@ type IContractCaller interface {
 		globalTableRootReferenceTimestamp uint32,
 	) (*ethereumTypes.Receipt, error)
 
-	GetAVSConfig(avsAddress string) (*AVSConfig, error)
+	GetAVSConfig(avsAddress string, blockNumber uint64) (*AVSConfig, error)
 
-	GetOperatorSetCurveType(avsAddress string, operatorSetId uint32) (config.CurveType, error)
+	GetOperatorSetCurveType(avsAddress string, operatorSetId uint32, blockNumber uint64) (config.CurveType, error)
 
-	GetOperatorSetMembersWithPeering(avsAddress string, operatorSetId uint32) ([]*peering.OperatorPeerInfo, error)
+	GetOperatorSetMembersWithPeering(avsAddress string, operatorSetId uint32, blockNumber uint64) ([]*peering.OperatorPeerInfo, error)
 
-	GetOperatorSetDetailsForOperator(operatorAddress common.Address, avsAddress string, operatorSetId uint32) (*peering.OperatorSet, error)
+	GetOperatorSetDetailsForOperator(operatorAddress common.Address, avsAddress string, operatorSetId uint32, blockNumber uint64) (*peering.OperatorSet, error)
 
 	PublishMessageToInbox(ctx context.Context, avsAddress string, operatorSetId uint32, payload []byte) (*ethereumTypes.Receipt, error)
 
@@ -106,7 +106,7 @@ type IContractCaller interface {
 
 	CalculateBN254CertificateDigestBytes(ctx context.Context, referenceTimestamp uint32, messageHash [32]byte) ([]byte, error)
 
-	GetExecutorOperatorSetTaskConfig(ctx context.Context, avsAddress common.Address, opsetId uint32) (*TaskMailboxExecutorOperatorSetConfig, error)
+	GetExecutorOperatorSetTaskConfig(ctx context.Context, avsAddress common.Address, opsetId uint32, blockNumber uint64) (*TaskMailboxExecutorOperatorSetConfig, error)
 
 	// ------------------------------------------------------------------------
 	// Helper functions for test setup

--- a/ponos/pkg/executor/auth_integration_test.go
+++ b/ponos/pkg/executor/auth_integration_test.go
@@ -249,6 +249,7 @@ func TestAuthenticationWithRealExecutor(t *testing.T) {
 			AvsAddress:        chainConfig.AVSAccountAddress,
 			Payload:           []byte("test"),
 			Signature:         []byte("sig"),
+			TaskBlockNumber:   0,
 			OperatorSetId:     1,
 		})
 

--- a/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/kubernetesPerformer_test.go
+++ b/ponos/pkg/executor/avsPerformer/avsKubernetesPerformer/kubernetesPerformer_test.go
@@ -90,7 +90,7 @@ func (m *MockPeeringFetcher) ListAggregatorOperators(ctx context.Context, avsAdd
 	return args.Get(0).([]*peering.OperatorPeerInfo), args.Error(1)
 }
 
-func (m *MockPeeringFetcher) ListExecutorOperators(ctx context.Context, avsAddress string) ([]*peering.OperatorPeerInfo, error) {
+func (m *MockPeeringFetcher) ListExecutorOperators(ctx context.Context, avsAddress string, number uint64) ([]*peering.OperatorPeerInfo, error) {
 	args := m.Called(ctx, avsAddress)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/ponos/pkg/executor/executor_test.go
+++ b/ponos/pkg/executor/executor_test.go
@@ -242,6 +242,7 @@ func testWithKeyType(
 		simAggConfig.Avss[0].Address,
 		chainConfig.ExecOperatorAccountAddress,
 		1,
+		0,
 		payloadJsonBytes,
 	)
 
@@ -267,6 +268,7 @@ func testWithKeyType(
 		ExecutorAddress:   chainConfig.ExecOperatorAccountAddress,
 		Payload:           payloadJsonBytes,
 		Signature:         payloadSig,
+		TaskBlockNumber:   0,
 		OperatorSetId:     1,
 	})
 	if err != nil {

--- a/ponos/pkg/executor/executor_test.go
+++ b/ponos/pkg/executor/executor_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/peering/peeringDataFetcher"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/signer"
 	"math/big"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -235,14 +236,21 @@ func testWithKeyType(
 	// give containers time to start.
 	time.Sleep(5 * time.Second)
 	taskId := "0x0000000000000000000000000000000000000000000000000000000000000001"
-
+	strBlockNumber, err := l1EthereumClient.GetBlockNumber(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get L1 block strBlockNumber: %v", err)
+	}
+	blockNumber, err := strconv.ParseUint(strBlockNumber, 10, 64)
+	if err != nil {
+		t.Fatalf("Failed to parse L1 block strBlockNumber: %v", err)
+	}
 	payloadJsonBytes := util.BigIntToHex(new(big.Int).SetUint64(4))
 	encodedMessage := util.EncodeTaskSubmissionMessage(
 		taskId,
 		simAggConfig.Avss[0].Address,
 		chainConfig.ExecOperatorAccountAddress,
 		1,
-		0,
+		blockNumber,
 		payloadJsonBytes,
 	)
 
@@ -268,7 +276,7 @@ func testWithKeyType(
 		ExecutorAddress:   chainConfig.ExecOperatorAccountAddress,
 		Payload:           payloadJsonBytes,
 		Signature:         payloadSig,
-		TaskBlockNumber:   0,
+		TaskBlockNumber:   blockNumber,
 		OperatorSetId:     1,
 	})
 	if err != nil {

--- a/ponos/pkg/executor/executor_test.go
+++ b/ponos/pkg/executor/executor_test.go
@@ -240,9 +240,10 @@ func testWithKeyType(
 	if err != nil {
 		t.Fatalf("Failed to get L1 block strBlockNumber: %v", err)
 	}
-	blockNumber, err := strconv.ParseUint(strBlockNumber, 10, 64)
+	// Parse hex string (e.g., "0x86d4dd") to uint64
+	blockNumber, err := strconv.ParseUint(strBlockNumber[2:], 16, 64)
 	if err != nil {
-		t.Fatalf("Failed to parse L1 block strBlockNumber: %v", err)
+		t.Fatalf("Failed to parse L1 block strBlockNumber %s: %v", strBlockNumber, err)
 	}
 	payloadJsonBytes := util.BigIntToHex(new(big.Int).SetUint64(4))
 	encodedMessage := util.EncodeTaskSubmissionMessage(

--- a/ponos/pkg/operator/operator.go
+++ b/ponos/pkg/operator/operator.go
@@ -95,7 +95,7 @@ func RegisterOperatorToOperatorSets(
 			zap.String("txHash", tx.TxHash.String()),
 		)
 
-		setCurveType, err := avsContractCaller.GetOperatorSetCurveType(avsAddress.String(), operatorSetId)
+		setCurveType, err := avsContractCaller.GetOperatorSetCurveType(avsAddress.String(), operatorSetId, 0)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get operator set curve type: %w", err)
 		}

--- a/ponos/pkg/operatorManager/operatorManager.go
+++ b/ponos/pkg/operatorManager/operatorManager.go
@@ -21,7 +21,6 @@ type OperatorManagerConfig struct {
 }
 
 type PeerWeight struct {
-	BlockNumber            uint64
 	ChainId                config.ChainId
 	OperatorSetId          uint32
 	RootReferenceTimestamp uint32
@@ -54,7 +53,7 @@ func NewOperatorManager(
 	}
 }
 
-func (om *OperatorManager) GetCurveTypeForOperatorSet(ctx context.Context, avsAddress string, operatorSetId uint32) (config.CurveType, error) {
+func (om *OperatorManager) GetCurveTypeForOperatorSet(_ context.Context, avsAddress string, operatorSetId uint32, blockNumber uint64) (config.CurveType, error) {
 	l1Cc, err := om.getContractCallerForChainId(om.config.L1ChainId)
 	if err != nil {
 		om.logger.Sugar().Errorw("Failed to get contract caller for L1 chain ID",
@@ -64,20 +63,19 @@ func (om *OperatorManager) GetCurveTypeForOperatorSet(ctx context.Context, avsAd
 		return config.CurveTypeUnknown, err
 	}
 
-	// Use latest block (0) for GetCurveTypeForOperatorSet since it's not task-specific
-	return l1Cc.GetOperatorSetCurveType(avsAddress, operatorSetId, 0)
+	return l1Cc.GetOperatorSetCurveType(avsAddress, operatorSetId, blockNumber)
 }
 
 // TODO(seanmcgary): extend/rename this later to support the aggregator as well when we add distributed aggregation
 func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 	ctx context.Context,
 	chainId config.ChainId,
-	taskBlockNumber uint64,
+	sourceBlockNumber uint64,
 	operatorSetId uint32,
 ) (*PeerWeight, error) {
 	om.logger.Sugar().Infow("Getting executor peers and weights for block",
 		zap.Uint32("chainId", uint32(chainId)),
-		zap.Uint64("blockNumber", taskBlockNumber),
+		zap.Uint64("sourceBlockNumber", sourceBlockNumber),
 		zap.Uint32("operatorSetId", operatorSetId),
 	)
 	l1Cc, err := om.getContractCallerForChainId(om.config.L1ChainId)
@@ -105,7 +103,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 
 	var supportedChainsBlockRef int64
 	if chainId == om.config.L1ChainId {
-		supportedChainsBlockRef = int64(taskBlockNumber)
+		supportedChainsBlockRef = int64(sourceBlockNumber)
 	} else {
 		// if this is not the L1, then we need to use the block number from the latest reference time
 		// NOTE: there are potential edge cases where due to the L1 and L2 blocks not aligning 1 to 1.
@@ -114,7 +112,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 	}
 	om.logger.Sugar().Debugw("Fetching supported chains for multichain",
 		zap.Uint32("chainId", uint32(chainId)),
-		zap.Uint64("blockNumber", taskBlockNumber),
+		zap.Uint64("sourceBlockNumber", sourceBlockNumber),
 		zap.Int64("supportedChainsBlockRef", supportedChainsBlockRef),
 		zap.String("avsAddress", om.config.AvsAddress),
 		zap.Uint32("operatorSetId", operatorSetId),
@@ -122,7 +120,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 	destChainIds, tableUpdaterAddresses, err := l1Cc.GetSupportedChainsForMultichain(ctx, supportedChainsBlockRef)
 	if err != nil {
 		om.logger.Sugar().Errorw("Failed to get supported chains for multichain",
-			zap.Uint64("BlockNumber", taskBlockNumber),
+			zap.Uint64("SourceBlockNumber", sourceBlockNumber),
 			zap.Error(err),
 		)
 		return nil, err
@@ -138,32 +136,32 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 	// if there is no table updater, then this chain is likely misconfigured or not supported
 	if destTableUpdaterAddress == (common.Address{}) {
 		om.logger.Sugar().Errorw("No table updater address found for chain",
-			zap.Uint32("ChainId", uint32(chainId)),
-			zap.Uint64("BlockNumber", taskBlockNumber),
+			zap.Uint32("chainId", uint32(chainId)),
+			zap.Uint64("sourceBlockNumber", sourceBlockNumber),
 		)
 		return nil, fmt.Errorf("no table updater address found for chain ID %d", chainId)
 	}
 	om.logger.Sugar().Infow("Found table updater address for chain",
 		zap.Uint32("chainId", uint32(chainId)),
-		zap.Uint64("blockNumber", taskBlockNumber),
+		zap.Uint64("blockNumber", sourceBlockNumber),
 		zap.String("tableUpdaterAddress", destTableUpdaterAddress.Hex()),
 		zap.String("avsAddress", om.config.AvsAddress),
 		zap.Uint32("operatorSetId", operatorSetId),
 	)
 
 	// this will tell us when the global root was last updated for this chain
-	latestReferenceTimeAndBlock, err := targetChainCc.GetTableUpdaterReferenceTimeAndBlock(ctx, destTableUpdaterAddress, taskBlockNumber)
+	latestReferenceTimeAndBlock, err := targetChainCc.GetTableUpdaterReferenceTimeAndBlock(ctx, destTableUpdaterAddress, sourceBlockNumber)
 	if err != nil {
 		om.logger.Sugar().Errorw("Failed to get latest reference time and block for table updater",
-			zap.Uint32("ChainId", uint32(chainId)),
-			zap.Uint64("BlockNumber", taskBlockNumber),
+			zap.Uint32("chainId", uint32(chainId)),
+			zap.Uint64("sourceBlockNumber", sourceBlockNumber),
 			zap.Error(err),
 		)
 		return nil, err
 	}
 	om.logger.Sugar().Infow("Latest reference time and block for table updater",
 		zap.Uint32("chainId", uint32(chainId)),
-		zap.Uint64("blockNumber", taskBlockNumber),
+		zap.Uint64("sourceBlockNumber", sourceBlockNumber),
 		zap.Uint32("latestReferenceBlockNumber", latestReferenceTimeAndBlock.LatestReferenceBlockNumber),
 		zap.Uint32("latestReferenceTimestamp", latestReferenceTimeAndBlock.LatestReferenceTimestamp),
 		zap.String("avsAddress", om.config.AvsAddress),
@@ -178,7 +176,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 	//
 	// If this is the L1, we can use the task block number directly.
 	if chainId == om.config.L1ChainId {
-		blockForTableData = taskBlockNumber
+		blockForTableData = sourceBlockNumber
 	} else {
 		// if this is not the L1, then we need to use the block number from the latest reference time
 		blockForTableData = uint64(latestReferenceTimeAndBlock.LatestReferenceBlockNumber)
@@ -190,7 +188,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 		om.logger.Sugar().Errorw("Failed to get operator table data",
 			zap.String("avsAddress", om.config.AvsAddress),
 			zap.Uint32("operatorSetId", operatorSetId),
-			zap.Uint64("blockNumber", taskBlockNumber),
+			zap.Uint64("sourceBlockNumber", sourceBlockNumber),
 			zap.Error(err),
 		)
 		return nil, err
@@ -198,7 +196,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 	om.logger.Sugar().Infow("Fetched operator table data",
 		zap.String("avsAddress", om.config.AvsAddress),
 		zap.Uint32("operatorSetId", operatorSetId),
-		zap.Uint64("blockNumber", taskBlockNumber),
+		zap.Uint64("sourceBlockNumber", sourceBlockNumber),
 		zap.Int("operatorCount", len(tableData.Operators)),
 		zap.Int("weightCount", len(tableData.OperatorWeights)),
 	)
@@ -209,7 +207,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 		operatorWeights[operator.String()] = weight
 	}
 
-	operators, err := om.peeringDataFetcher.ListExecutorOperators(ctx, om.config.AvsAddress, taskBlockNumber)
+	operators, err := om.peeringDataFetcher.ListExecutorOperators(ctx, om.config.AvsAddress, sourceBlockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list executor Operators: %w", err)
 	}
@@ -236,13 +234,12 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 		referenceTimestamp = latestReferenceTimeAndBlock.LatestReferenceTimestamp // use latest reference timestamp for L2
 	}
 
-	curveType, err := l1Cc.GetOperatorSetCurveType(om.config.AvsAddress, operatorSetId, taskBlockNumber)
+	curveType, err := l1Cc.GetOperatorSetCurveType(om.config.AvsAddress, operatorSetId, sourceBlockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operator set curve type: %w", err)
 	}
 
 	return &PeerWeight{
-		BlockNumber:            taskBlockNumber,
 		ChainId:                chainId,
 		OperatorSetId:          operatorSetId,
 		RootReferenceTimestamp: referenceTimestamp,
@@ -250,7 +247,6 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 		Operators:              operators,
 		CurveType:              curveType,
 	}, nil
-
 }
 
 func (om *OperatorManager) getContractCallerForChainId(chainId config.ChainId) (contractCaller.IContractCaller, error) {

--- a/ponos/pkg/operatorManager/operatorManager.go
+++ b/ponos/pkg/operatorManager/operatorManager.go
@@ -64,7 +64,8 @@ func (om *OperatorManager) GetCurveTypeForOperatorSet(ctx context.Context, avsAd
 		return config.CurveTypeUnknown, err
 	}
 
-	return l1Cc.GetOperatorSetCurveType(avsAddress, operatorSetId)
+	// Use latest block (0) for GetCurveTypeForOperatorSet since it's not task-specific
+	return l1Cc.GetOperatorSetCurveType(avsAddress, operatorSetId, 0)
 }
 
 // TODO(seanmcgary): extend/rename this later to support the aggregator as well when we add distributed aggregation
@@ -208,7 +209,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 		operatorWeights[operator.String()] = weight
 	}
 
-	operators, err := om.peeringDataFetcher.ListExecutorOperators(ctx, om.config.AvsAddress)
+	operators, err := om.peeringDataFetcher.ListExecutorOperators(ctx, om.config.AvsAddress, taskBlockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list executor Operators: %w", err)
 	}
@@ -235,7 +236,7 @@ func (om *OperatorManager) GetExecutorPeersAndWeightsForBlock(
 		referenceTimestamp = latestReferenceTimeAndBlock.LatestReferenceTimestamp // use latest reference timestamp for L2
 	}
 
-	curveType, err := l1Cc.GetOperatorSetCurveType(om.config.AvsAddress, operatorSetId)
+	curveType, err := l1Cc.GetOperatorSetCurveType(om.config.AvsAddress, operatorSetId, taskBlockNumber)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get operator set curve type: %w", err)
 	}

--- a/ponos/pkg/peering/localPeeringDataFetcher/localPeeringDataFetcher.go
+++ b/ponos/pkg/peering/localPeeringDataFetcher/localPeeringDataFetcher.go
@@ -28,10 +28,10 @@ func NewLocalPeeringDataFetcher(
 	}
 }
 
-func (lpdf *LocalPeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAddress string, number uint64) ([]*peering.OperatorPeerInfo, error) {
+func (lpdf *LocalPeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAddress string, blockNumber uint64) ([]*peering.OperatorPeerInfo, error) {
 	return lpdf.operatorPeers, nil
 }
 
-func (lpdf *LocalPeeringDataFetcher) ListAggregatorOperators(ctx context.Context, avsAddress string) ([]*peering.OperatorPeerInfo, error) {
+func (lpdf *LocalPeeringDataFetcher) ListAggregatorOperators(ctx context.Context, avsAddress string, blockNumber uint64) ([]*peering.OperatorPeerInfo, error) {
 	return lpdf.aggregatorPeers, nil
 }

--- a/ponos/pkg/peering/localPeeringDataFetcher/localPeeringDataFetcher.go
+++ b/ponos/pkg/peering/localPeeringDataFetcher/localPeeringDataFetcher.go
@@ -28,7 +28,7 @@ func NewLocalPeeringDataFetcher(
 	}
 }
 
-func (lpdf *LocalPeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAddress string) ([]*peering.OperatorPeerInfo, error) {
+func (lpdf *LocalPeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAddress string, number uint64) ([]*peering.OperatorPeerInfo, error) {
 	return lpdf.operatorPeers, nil
 }
 

--- a/ponos/pkg/peering/peering.go
+++ b/ponos/pkg/peering/peering.go
@@ -53,6 +53,6 @@ func (opi *OperatorPeerInfo) IncludesOperatorSetId(operatorSetId uint32) bool {
 }
 
 type IPeeringDataFetcher interface {
-	ListExecutorOperators(ctx context.Context, avsAddress string) ([]*OperatorPeerInfo, error)
-	ListAggregatorOperators(ctx context.Context, avsAddress string) ([]*OperatorPeerInfo, error)
+	ListExecutorOperators(ctx context.Context, avsAddress string, blockNumber uint64) ([]*OperatorPeerInfo, error)
+	ListAggregatorOperators(ctx context.Context, avsAddress string, blockNumber uint64) ([]*OperatorPeerInfo, error)
 }

--- a/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher.go
+++ b/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher.go
@@ -23,8 +23,8 @@ func NewPeeringDataFetcher(
 	}
 }
 
-func (pdf *PeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAddress string) ([]*peering.OperatorPeerInfo, error) {
-	avsConfig, err := pdf.contractCaller.GetAVSConfig(avsAddress)
+func (pdf *PeeringDataFetcher) ListExecutorOperators(_ context.Context, avsAddress string, blockNumber uint64) ([]*peering.OperatorPeerInfo, error) {
+	avsConfig, err := pdf.contractCaller.GetAVSConfig(avsAddress, blockNumber)
 	if err != nil {
 		pdf.logger.Sugar().Errorw("Failed to get AVS config",
 			zap.String("avsAddress", avsAddress),
@@ -37,7 +37,7 @@ func (pdf *PeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAdd
 
 	// iterate over all operator sets and get their members with peering info
 	for _, operatorSetId := range avsConfig.ExecutorOperatorSetIds {
-		peeringInfos, err := pdf.contractCaller.GetOperatorSetMembersWithPeering(avsAddress, operatorSetId)
+		peeringInfos, err := pdf.contractCaller.GetOperatorSetMembersWithPeering(avsAddress, operatorSetId, blockNumber)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get operator set members with peering %w", err)
 		}
@@ -58,8 +58,9 @@ func (pdf *PeeringDataFetcher) ListExecutorOperators(ctx context.Context, avsAdd
 	return result, nil
 }
 
-func (pdf *PeeringDataFetcher) ListAggregatorOperators(ctx context.Context, avsAddress string) ([]*peering.OperatorPeerInfo, error) {
-	avsConfig, err := pdf.contractCaller.GetAVSConfig(avsAddress)
+func (pdf *PeeringDataFetcher) ListAggregatorOperators(_ context.Context, avsAddress string, blockNumber uint64) ([]*peering.OperatorPeerInfo, error) {
+	// Use blockNumber 0 to get the latest state
+	avsConfig, err := pdf.contractCaller.GetAVSConfig(avsAddress, blockNumber)
 	if err != nil {
 		pdf.logger.Sugar().Errorw("Failed to get AVS config", zap.Error(err))
 		return nil, err
@@ -70,5 +71,5 @@ func (pdf *PeeringDataFetcher) ListAggregatorOperators(ctx context.Context, avsA
 		return nil, nil
 	}
 
-	return pdf.contractCaller.GetOperatorSetMembersWithPeering(avsAddress, avsConfig.AggregatorOperatorSetId)
+	return pdf.contractCaller.GetOperatorSetMembersWithPeering(avsAddress, avsConfig.AggregatorOperatorSetId, blockNumber)
 }

--- a/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
+++ b/ponos/pkg/peering/peeringDataFetcher/peeringDataFetcher_test.go
@@ -174,7 +174,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 
 			var peers []*peering.OperatorPeerInfo
 			if tc.operatorType == "executor" {
-				peers, err = pdf.ListExecutorOperators(ctx, chainConfig.AVSAccountAddress)
+				peers, err = pdf.ListExecutorOperators(ctx, chainConfig.AVSAccountAddress, 0)
 				if err != nil {
 					t.Fatalf("Failed to list executor operators: %v", err)
 				}
@@ -185,7 +185,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 				assert.Equal(t, peers[0].OperatorSets[0].NetworkAddress, socket)
 
 			} else if tc.operatorType == "aggregator" {
-				peers, err = pdf.ListAggregatorOperators(ctx, chainConfig.AVSAccountAddress)
+				peers, err = pdf.ListAggregatorOperators(ctx, chainConfig.AVSAccountAddress, 0)
 				if err != nil {
 					t.Fatalf("Failed to list aggregator operators: %v", err)
 				}
@@ -380,7 +380,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 
 			var peers []*peering.OperatorPeerInfo
 			if tc.operatorType == "executor" {
-				peers, err = pdf.ListExecutorOperators(ctx, chainConfig.AVSAccountAddress)
+				peers, err = pdf.ListExecutorOperators(ctx, chainConfig.AVSAccountAddress, 0)
 				if err != nil {
 					t.Fatalf("Failed to list executor operators: %v", err)
 				}
@@ -391,7 +391,7 @@ func Test_PeeringDataFetcher(t *testing.T) {
 				assert.Equal(t, peers[0].OperatorSets[0].NetworkAddress, socket)
 
 			} else if tc.operatorType == "aggregator" {
-				peers, err = pdf.ListAggregatorOperators(ctx, chainConfig.AVSAccountAddress)
+				peers, err = pdf.ListAggregatorOperators(ctx, chainConfig.AVSAccountAddress, 0)
 				if err != nil {
 					t.Fatalf("Failed to list aggregator operators: %v", err)
 				}

--- a/ponos/pkg/performerTask/performerTask.go
+++ b/ponos/pkg/performerTask/performerTask.go
@@ -13,6 +13,7 @@ type PerformerTask struct {
 	AggregatorAddress  string
 	OperatorSetId      uint32
 	ReferenceTimestamp uint32
+	TaskBlockNumber    uint64
 }
 
 // NewPerformerTaskFromTaskSubmissionProto creates a new PerformerTask from a TaskSubmission proto
@@ -25,6 +26,7 @@ func NewPerformerTaskFromTaskSubmissionProto(t *v1.TaskSubmission) *PerformerTas
 		AggregatorAddress:  t.AggregatorAddress,
 		OperatorSetId:      t.OperatorSetId,
 		ReferenceTimestamp: t.ReferenceTimestamp,
+		TaskBlockNumber:    t.TaskBlockNumber,
 	}
 }
 

--- a/ponos/pkg/signing/aggregation/aggregation_test.go
+++ b/ponos/pkg/signing/aggregation/aggregation_test.go
@@ -124,7 +124,6 @@ func Test_Aggregation(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,  // taskCreatedBlock
 			1,    // operatorSetId
 			7500, // thresholdBips (3/4 = 7500 bips)
 			taskData,
@@ -214,7 +213,6 @@ func Test_Aggregation(t *testing.T) {
 		agg, err := NewECDSATaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,  // taskCreatedBlock
 			1,    // operatorSetId
 			7500, // thresholdBips (3/4 = 7500 bips)
 			taskData,
@@ -292,7 +290,6 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,  // taskCreatedBlock
 			1,    // operatorSetId
 			6000, // thresholdBips (3/5 = 6000 bips)
 			taskData,
@@ -409,7 +406,6 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			10000, // 100% threshold (10000 bips) - requires the single operator
 			taskData,
@@ -489,7 +485,6 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			10000, // 100% threshold (10000 bips)
 			taskData,
@@ -554,7 +549,6 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,  // taskCreatedBlock
 			1,    // operatorSetId
 			6000, // thresholdBips (3/5 = 6000 bips = 60% participation required)
 			taskData,
@@ -632,7 +626,6 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		agg, err := NewECDSATaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,  // taskCreatedBlock
 			1,    // operatorSetId
 			6000, // thresholdBips (3/5 = 6000 bips)
 			taskData,
@@ -754,7 +747,6 @@ func Test_MostCommonDigestTracking(t *testing.T) {
 		agg, err := NewECDSATaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			10000, // 100% threshold (10000 bips)
 			taskData,
@@ -816,7 +808,6 @@ func Test_OutputDigestSecurityValidation(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			10000, // 100% threshold (10000 bips)
 			taskData,
@@ -883,7 +874,6 @@ func Test_OutputDigestSecurityValidation(t *testing.T) {
 		agg, err := NewECDSATaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			10000, // 100% threshold (10000 bips)
 			taskData,
@@ -949,7 +939,6 @@ func Test_NonSignerOrdering(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			6000, // 60% threshold (3/5 operators)
 			taskData,
@@ -1034,7 +1023,6 @@ func Test_NonSignerOrdering(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			10000, // 100% threshold
 			taskData,
@@ -1089,7 +1077,6 @@ func Test_NonSignerOrdering(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			2500, // 25% threshold (can be met with 0 signers if we want to test)
 			taskData,
@@ -1149,7 +1136,6 @@ func Test_NonSignerOrdering(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			6667, // 66.67% threshold (2/3)
 			taskData,
@@ -1210,7 +1196,6 @@ func Test_DigestBasedAggregation(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,  // taskCreatedBlock
 			1,    // operatorSetId
 			6667, // thresholdBips (2/3 = 66.67%)
 			taskData,
@@ -1324,7 +1309,6 @@ func Test_TaskIDMismatchValidation(t *testing.T) {
 		agg, err := NewBN254TaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			5000, // 50% threshold (5000 bips)
 			taskData,
@@ -1393,7 +1377,6 @@ func Test_TaskIDMismatchValidation(t *testing.T) {
 		agg, err := NewECDSATaskResultAggregator(
 			context.Background(),
 			taskId,
-			100,
 			1,
 			5000, // 50% threshold (5000 bips)
 			taskData,

--- a/ponos/pkg/signing/aggregation/bn254.go
+++ b/ponos/pkg/signing/aggregation/bn254.go
@@ -48,7 +48,6 @@ type AggregatedBN254Certificate struct {
 type BN254TaskResultAggregator struct {
 	mu                 sync.Mutex
 	TaskId             string
-	TaskCreatedBlock   uint64
 	OperatorSetId      uint32
 	ThresholdBips      uint16
 	TaskData           []byte
@@ -64,9 +63,8 @@ type BN254TaskResultAggregator struct {
 // NewBN254TaskResultAggregator initializes a new aggregation certificate for a task window.
 // All required data must be provided as arguments; no network or chain calls are performed.
 func NewBN254TaskResultAggregator(
-	ctx context.Context,
+	_ context.Context,
 	taskId string,
-	taskCreatedBlock uint64,
 	operatorSetId uint32,
 	thresholdBips uint16,
 	taskData []byte,
@@ -92,7 +90,6 @@ func NewBN254TaskResultAggregator(
 
 	cert := &BN254TaskResultAggregator{
 		TaskId:             taskId,
-		TaskCreatedBlock:   taskCreatedBlock,
 		OperatorSetId:      operatorSetId,
 		ThresholdBips:      thresholdBips,
 		TaskData:           taskData,

--- a/ponos/pkg/signing/aggregation/bn254_mock_test.go
+++ b/ponos/pkg/signing/aggregation/bn254_mock_test.go
@@ -83,7 +83,6 @@ func TestBN254ContractSubmission(t *testing.T) {
 	aggregator, err := NewBN254TaskResultAggregator(
 		ctx,
 		taskId,
-		12345,
 		operatorSetId,
 		7500,
 		[]byte("task data"),
@@ -274,7 +273,6 @@ func TestBN254ThresholdEdgeCases(t *testing.T) {
 			aggregator, err := NewBN254TaskResultAggregator(
 				ctx,
 				taskId,
-				12345,
 				operatorSetId,
 				tc.thresholdBips,
 				[]byte("task data"),

--- a/ponos/pkg/signing/aggregation/ecdsa.go
+++ b/ponos/pkg/signing/aggregation/ecdsa.go
@@ -112,7 +112,6 @@ type aggregatedECDSAOperators struct {
 type ECDSATaskResultAggregator struct {
 	mu                 sync.Mutex
 	TaskId             string
-	TaskCreatedBlock   uint64
 	OperatorSetId      uint32
 	ThresholdBips      uint16
 	TaskData           []byte
@@ -129,7 +128,6 @@ type ECDSATaskResultAggregator struct {
 func NewECDSATaskResultAggregator(
 	_ context.Context,
 	taskId string,
-	taskCreatedBlock uint64,
 	operatorSetId uint32,
 	thresholdBips uint16,
 	taskData []byte,
@@ -152,7 +150,6 @@ func NewECDSATaskResultAggregator(
 
 	cert := &ECDSATaskResultAggregator{
 		TaskId:              taskId,
-		TaskCreatedBlock:    taskCreatedBlock,
 		OperatorSetId:       operatorSetId,
 		ThresholdBips:       thresholdBips,
 		TaskData:            taskData,

--- a/ponos/pkg/signing/aggregation/ecdsa_mock_test.go
+++ b/ponos/pkg/signing/aggregation/ecdsa_mock_test.go
@@ -149,7 +149,6 @@ func TestECDSAContractSubmission(t *testing.T) {
 	aggregator, err := NewECDSATaskResultAggregator(
 		ctx,
 		taskId,
-		12345,
 		operatorSetId,
 		7500,
 		[]byte("task data"),

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -161,6 +161,7 @@ func (ts *TaskSession[SigT, CertT, PubKeyT]) generateExecutorSignature(executorA
 		ts.Task.AVSAddress,
 		executorAddress,
 		ts.Task.OperatorSetId,
+		ts.Task.BlockNumber,
 		ts.Task.Payload,
 	)
 	return ts.signer.SignMessage(encodedMessage)
@@ -256,6 +257,7 @@ func (ts *TaskSession[SigT, CertT, PubKeyT]) Broadcast() (*CertT, error) {
 				Signature:          signature,
 				OperatorSetId:      ts.Task.OperatorSetId,
 				ReferenceTimestamp: ts.operatorPeersWeight.RootReferenceTimestamp,
+				TaskBlockNumber:    ts.Task.BlockNumber,
 			}
 			ts.logger.Sugar().Infow("broadcasting task session to operators",
 				zap.Any("taskSubmission", taskSubmission),

--- a/ponos/pkg/taskSession/taskSession_test.go
+++ b/ponos/pkg/taskSession/taskSession_test.go
@@ -335,8 +335,9 @@ func TestTaskSession_Process_ContextHandling(t *testing.T) {
 
 		// Mock client respects context timeout and returns context.DeadlineExceeded
 		result, err := mockClient.SubmitTask(ctx, &executorV1.TaskSubmission{
-			TaskId:  "test",
-			Payload: []byte("test-payload"),
+			TaskId:          "test",
+			Payload:         []byte("test-payload"),
+			TaskBlockNumber: 0,
 		})
 
 		require.Error(t, err)
@@ -359,8 +360,9 @@ func TestTaskSession_Process_ContextHandling(t *testing.T) {
 		defer cancel()
 
 		result, err := mockClient.SubmitTask(ctx, &executorV1.TaskSubmission{
-			TaskId:  "test",
-			Payload: []byte("test-payload"),
+			TaskId:          "test",
+			Payload:         []byte("test-payload"),
+			TaskBlockNumber: 0,
 		})
 
 		require.NoError(t, err)
@@ -389,14 +391,16 @@ func TestTaskSession_Process_ContextHandling(t *testing.T) {
 
 		// Fast client should succeed
 		fastResult, fastErr := fastClient.SubmitTask(ctx, &executorV1.TaskSubmission{
-			TaskId: "test",
+			TaskId:          "test",
+			TaskBlockNumber: 0,
 		})
 		require.NoError(t, fastErr)
 		assert.Equal(t, []byte("fast"), fastResult.Output)
 
 		// Slow client should timeout
 		slowResult, slowErr := slowClient.SubmitTask(ctx, &executorV1.TaskSubmission{
-			TaskId: "test",
+			TaskId:          "test",
+			TaskBlockNumber: 0,
 		})
 		require.Error(t, slowErr)
 		assert.Nil(t, slowResult)
@@ -793,12 +797,18 @@ func TestTaskSession_MockIntegration(t *testing.T) {
 		defer cancel2()
 
 		// Fast client should succeed within timeout
-		result1, err1 := fastClient.SubmitTask(ctx1, &executorV1.TaskSubmission{TaskId: "test"})
+		result1, err1 := fastClient.SubmitTask(ctx1, &executorV1.TaskSubmission{
+			TaskId:          "test",
+			TaskBlockNumber: 0,
+		})
 		require.NoError(t, err1)
 		assert.Equal(t, []byte("fast-response"), result1.Output)
 
 		// Slow client should timeout
-		result2, err2 := slowClient.SubmitTask(ctx2, &executorV1.TaskSubmission{TaskId: "test"})
+		result2, err2 := slowClient.SubmitTask(ctx2, &executorV1.TaskSubmission{
+			TaskId:          "test",
+			TaskBlockNumber: 0,
+		})
 		require.Error(t, err2)
 		assert.Nil(t, result2)
 		assert.Equal(t, context.DeadlineExceeded, err2)

--- a/ponos/pkg/types/task.go
+++ b/ponos/pkg/types/task.go
@@ -35,16 +35,17 @@ type TaskEvent struct {
 }
 
 type Task struct {
-	TaskId              string         `json:"taskId"`
-	AVSAddress          string         `json:"avsAddress"`
-	OperatorSetId       uint32         `json:"operatorSetId"`
-	CallbackAddr        string         `json:"callbackAddr"`
-	DeadlineUnixSeconds *time.Time     `json:"deadline"`
-	ThresholdBips       uint16         `json:"stakeRequired"`
-	Payload             []byte         `json:"payload"`
-	ChainId             config.ChainId `json:"chainId"`
-	BlockNumber         uint64         `json:"blockNumber"`
-	BlockHash           string         `json:"blockHash"`
+	TaskId                 string         `json:"taskId"`
+	AVSAddress             string         `json:"avsAddress"`
+	OperatorSetId          uint32         `json:"operatorSetId"`
+	CallbackAddr           string         `json:"callbackAddr"`
+	DeadlineUnixSeconds    *time.Time     `json:"deadline"`
+	ThresholdBips          uint16         `json:"stakeRequired"`
+	Payload                []byte         `json:"payload"`
+	ChainId                config.ChainId `json:"chainId"`
+	SourceBlockNumber      uint64         `json:"sourceBlockNumber"`
+	L1ReferenceBlockNumber uint64         `json:"l1ReferenceBlockNumber"`
+	BlockHash              string         `json:"blockHash"`
 }
 
 type TaskResult struct {
@@ -155,7 +156,7 @@ func NewTaskFromLog(log *log.DecodedLog, block *ethereum.EthereumBlock, inboxAdd
 		DeadlineUnixSeconds: &taskDeadlineTime,
 		Payload:             od.Payload,
 		ChainId:             block.ChainId,
-		BlockNumber:         block.Number.Value(),
+		SourceBlockNumber:   block.Number.Value(),
 		BlockHash:           block.Hash.Value(),
 	}, nil
 }

--- a/ponos/pkg/util/signatures.go
+++ b/ponos/pkg/util/signatures.go
@@ -42,7 +42,7 @@ func (tsd *TaskSubmissionSignatureData) ToSigningBytes() []byte {
 	binary.BigEndian.PutUint32(operSetId[28:], tsd.OperatorSetId)
 	result = append(result, operSetId...)
 
-	// BlockNumber as uint64 padded to 32 bytes
+	// SourceBlockNumber as uint64 padded to 32 bytes
 	blockNum := make([]byte, 32)
 	binary.BigEndian.PutUint64(blockNum[24:], tsd.BlockNumber)
 	result = append(result, blockNum...)

--- a/ponos/pkg/util/signatures.go
+++ b/ponos/pkg/util/signatures.go
@@ -12,17 +12,18 @@ type TaskSubmissionSignatureData struct {
 	AvsAddress      string   // 20 bytes padded to 32
 	ExecutorAddress string   // 20 bytes padded to 32
 	OperatorSetId   uint32   // 4 bytes padded to 32
+	BlockNumber     uint64   // 8 bytes padded to 32
 	PayloadDigest   [32]byte // 32 bytes (keccak256 of payload)
 }
 
 // ToSigningBytes creates deterministic ABI-encoded bytes for signing
 // Format: taskId(bytes32) || avsAddress(address) || executorAddress(address) ||
 //
-//	operatorSetId(uint32) || payloadDigest(bytes32)
+//	operatorSetId(uint32) || blockNumber(uint64) || payloadDigest(bytes32)
 //
-// Total: 160 bytes
+// Total: 192 bytes
 func (tsd *TaskSubmissionSignatureData) ToSigningBytes() []byte {
-	result := make([]byte, 0, 160)
+	result := make([]byte, 0, 192)
 
 	// TaskId as 32 bytes
 	taskIdBytes := common.HexToHash(tsd.TaskId).Bytes()
@@ -40,6 +41,11 @@ func (tsd *TaskSubmissionSignatureData) ToSigningBytes() []byte {
 	operSetId := make([]byte, 32)
 	binary.BigEndian.PutUint32(operSetId[28:], tsd.OperatorSetId)
 	result = append(result, operSetId...)
+
+	// BlockNumber as uint64 padded to 32 bytes
+	blockNum := make([]byte, 32)
+	binary.BigEndian.PutUint64(blockNum[24:], tsd.BlockNumber)
+	result = append(result, blockNum...)
 
 	// Payload digest (already 32 bytes)
 	result = append(result, tsd.PayloadDigest[:]...)
@@ -90,6 +96,7 @@ func EncodeTaskSubmissionMessage(
 	avsAddress string,
 	executorAddress string,
 	operatorSetId uint32,
+	blockNumber uint64,
 	payload []byte,
 ) []byte {
 
@@ -100,6 +107,7 @@ func EncodeTaskSubmissionMessage(
 		AvsAddress:      avsAddress,
 		ExecutorAddress: executorAddress,
 		OperatorSetId:   operatorSetId,
+		BlockNumber:     blockNumber,
 		PayloadDigest:   [32]byte(payloadDigest),
 	}
 

--- a/ponos/protos/eigenlayer/hourglass/v1/executor/executor.proto
+++ b/ponos/protos/eigenlayer/hourglass/v1/executor/executor.proto
@@ -37,6 +37,7 @@ message TaskSubmission {
   uint32 operator_set_id = 6;
   uint32 reference_timestamp = 7;
   string executor_address = 8;
+  uint64 task_block_number = 9;  // Block number for consistent state queries
 }
 
 message TaskResult {


### PR DESCRIPTION
## Add Block Height Targeting for Contract Calls

### What Changed

  - Added TaskBlockNumber field to task submissions for precise historical state queries
  - Updated all contract caller interfaces to accept explicit blockNumber parameters
  - Modified signature verification to use block-specific operator set data

### Why

Previously, contract calls used the latest blockchain state instead of the historical state from task creation time, causing potential consensus failures when operator sets changed between task creation and
  execution.

### Key Changes

  - Proto: Added task_block_number to TaskSubmission messages
  - Signatures: Include block number in cryptographic task signatures (increased size from 160 to 192 bytes)
  - Contract Calls: All GetAVSConfig, GetOperatorSetCurveType, and operator queries now use historical block numbers
  - Tests: Updated all mocks and test data to include block numbers
