### PR TITLE
feat: implement DeRegisterAVS function

### DIFF
--- a/ponos/pkg/aggregator/aggregator.go
+++ b/ponos/pkg/aggregator/aggregator.go
@@ -277,10 +277,10 @@ func (a *Aggregator) registerAvs(avs *aggregatorConfig.AggregatorAvs) error {
 
 	// Add to map with exclusive lock (double-check pattern)
 	a.avsMutex.Lock()
-	defer a.avsMutex.Unlock()
 
 	// Double-check that it wasn't added while we were creating the AEM
 	if _, ok := a.avsManagers[avs.Address]; ok {
+		a.avsMutex.Unlock()
 		avsCancel() // Clean up context
 		return fmt.Errorf("AVS Execution Manager for %s already exists", avs.Address)
 	}

--- a/ponos/pkg/aggregator/aggregator.go
+++ b/ponos/pkg/aggregator/aggregator.go
@@ -3,6 +3,8 @@ package aggregator
 import (
 	"context"
 	"fmt"
+	"time"
+
 	aggregatorV1 "github.com/Layr-Labs/hourglass-monorepo/ponos/gen/protos/eigenlayer/hourglass/v1/aggregator"
 	commonV1 "github.com/Layr-Labs/hourglass-monorepo/ponos/gen/protos/eigenlayer/hourglass/v1/common"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/aggregator/aggregatorConfig"
@@ -28,7 +30,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"time"
 )
 
 type AggregatorConfig struct {
@@ -253,6 +254,25 @@ func (a *Aggregator) registerAvs(avs *aggregatorConfig.AggregatorAvs) error {
 	}
 
 	a.avsExecutionManagers[avs.Address] = aem
+	return nil
+}
+
+func (a *Aggregator) deregisterAvs(avsAddress string) error {
+	a.logger.Sugar().Infow("Deregistering AVS",
+		zap.String("avsAddress", avsAddress),
+	)
+
+	// Check if AVS execution manager exists
+	if _, ok := a.avsExecutionManagers[avsAddress]; !ok {
+		return fmt.Errorf("AVS %s is not registered", avsAddress)
+	}
+
+	// Remove AVS execution manager from map
+	delete(a.avsExecutionManagers, avsAddress)
+
+	a.logger.Sugar().Infow("AVS deregistered successfully",
+		zap.String("avsAddress", avsAddress),
+	)
 	return nil
 }
 

--- a/ponos/pkg/aggregator/aggregator_test.go
+++ b/ponos/pkg/aggregator/aggregator_test.go
@@ -1140,6 +1140,7 @@ func createTestAggregator(t *testing.T) *Aggregator {
 			Address:   "0xaggregator",
 			L1ChainId: config.ChainId_EthereumMainnet,
 		},
+		rootCtx:      context.Background(), // Set root context for tests
 		avsManagers:  make(map[string]*AvsExecutionManagerInfo),
 		authVerifier: nil, // No auth verification for these tests
 	}

--- a/ponos/pkg/aggregator/auth_integration_test.go
+++ b/ponos/pkg/aggregator/auth_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/config"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/contractCaller/caller"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/contractStore/inMemoryContractStore"
-	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/contracts"
+	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/eigenlayer"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/logger"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/peering/peeringDataFetcher"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/signer"
@@ -98,7 +98,11 @@ func TestAuthenticationWithRealAggregator(t *testing.T) {
 	pdf := peeringDataFetcher.NewPeeringDataFetcher(l1CC, l)
 
 	// Setup contract store and transaction log parser
-	contractStore := inMemoryContractStore.NewInMemoryContractStore([]*contracts.Contract{}, l)
+	// Load EigenLayer contracts that include mailbox contracts needed for AVS registration
+	eigenlayerContracts, err := eigenlayer.LoadContracts()
+	require.NoError(t, err)
+
+	contractStore := inMemoryContractStore.NewInMemoryContractStore(eigenlayerContracts, l)
 	tlp := transactionLogParser.NewTransactionLogParser(contractStore, l)
 
 	// Enable authentication for testing
@@ -283,11 +287,12 @@ func TestAuthenticationWithRealAggregator(t *testing.T) {
 			AvsAddress: chainConfig.AVSAccountAddress,
 		})
 
-		// Will fail with Unimplemented, but auth should pass
+		// Should fail because AVS was never registered, but auth should pass
 		assert.Error(t, err)
 		statusErr, ok := status.FromError(err)
 		assert.True(t, ok)
-		assert.Equal(t, codes.Unimplemented, statusErr.Code()) // Not an auth error
+		assert.Equal(t, codes.Internal, statusErr.Code()) // Not an auth error
+		assert.Contains(t, statusErr.Message(), "not registered")
 	})
 }
 

--- a/ponos/pkg/aggregator/handlers.go
+++ b/ponos/pkg/aggregator/handlers.go
@@ -25,7 +25,7 @@ func (a *Aggregator) RegisterAvs(ctx context.Context, request *aggregatorV1.Regi
 		return nil, err
 	}
 
-	err := a.registerAvs(&aggregatorConfig.AggregatorAvs{
+	err := a.registerAvs(ctx, &aggregatorConfig.AggregatorAvs{
 		Address: request.AvsAddress,
 		ChainIds: util.Map(request.ChainIds, func(id uint32, i uint64) uint {
 			return uint(id)

--- a/ponos/pkg/aggregator/handlers.go
+++ b/ponos/pkg/aggregator/handlers.go
@@ -31,6 +31,10 @@ func (a *Aggregator) RegisterAvs(ctx context.Context, request *aggregatorV1.Regi
 			return uint(id)
 		}),
 	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to register AVS: %v", err)
+	}
+
 	return &aggregatorV1.RegisterAvsResponse{
 		Success: err == nil,
 	}, nil
@@ -49,6 +53,10 @@ func (a *Aggregator) DeRegisterAvs(ctx context.Context, request *aggregatorV1.De
 	}
 
 	err := a.deregisterAvs(request.AvsAddress)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to deregister AVS: %v", err)
+	}
+
 	return &aggregatorV1.DeRegisterAvsResponse{
 		Success: err == nil,
 	}, nil

--- a/ponos/pkg/aggregator/handlers.go
+++ b/ponos/pkg/aggregator/handlers.go
@@ -25,7 +25,7 @@ func (a *Aggregator) RegisterAvs(ctx context.Context, request *aggregatorV1.Regi
 		return nil, err
 	}
 
-	err := a.registerAvs(ctx, &aggregatorConfig.AggregatorAvs{
+	err := a.registerAvs(&aggregatorConfig.AggregatorAvs{
 		Address: request.AvsAddress,
 		ChainIds: util.Map(request.ChainIds, func(id uint32, i uint64) uint {
 			return uint(id)

--- a/ponos/pkg/aggregator/handlers.go
+++ b/ponos/pkg/aggregator/handlers.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+
 	aggregatorV1 "github.com/Layr-Labs/hourglass-monorepo/ponos/gen/protos/eigenlayer/hourglass/v1/aggregator"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/aggregator/aggregatorConfig"
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/auth"
@@ -36,12 +37,21 @@ func (a *Aggregator) RegisterAvs(ctx context.Context, request *aggregatorV1.Regi
 }
 
 func (a *Aggregator) DeRegisterAvs(ctx context.Context, request *aggregatorV1.DeRegisterAvsRequest) (*aggregatorV1.DeRegisterAvsResponse, error) {
+	a.logger.Sugar().Infow("DeRegisterAvs called",
+		zap.String("avsAddress", request.AvsAddress),
+		zap.Bool("hasAuth", request.Auth != nil),
+		zap.Bool("authEnabled", a.authVerifier != nil),
+	)
+
 	// Verify authentication
 	if err := auth.HandleAuthError(a.verifyAuth(request.Auth)); err != nil {
 		return nil, err
 	}
 
-	return nil, status.Errorf(codes.Unimplemented, "DeRegisterAvs is not implemented yet")
+	err := a.deregisterAvs(request.AvsAddress)
+	return &aggregatorV1.DeRegisterAvsResponse{
+		Success: err == nil,
+	}, nil
 }
 
 // GetChallengeToken generates a challenge token for authentication


### PR DESCRIPTION
- implement DeRegisterAVS function, which removes the specified AVS resources from the Aggregator.
- Add `AvsExecutionManagerInfo` to have its own cancel context function
- Add mutex to thread-safe