### PR TITLE
refactor: simplifying EVMChainPoller latest block tracking

### DIFF
--- a/ponos/internal/tests/persistence/benchmark_test.go
+++ b/ponos/internal/tests/persistence/benchmark_test.go
@@ -160,13 +160,20 @@ func BenchmarkConcurrentOperations(b *testing.B) {
 func BenchmarkBlockOperations(b *testing.B) {
 	ctx := context.Background()
 
-	b.Run("InMemoryStore/SetBlock", func(b *testing.B) {
+	b.Run("InMemoryStore/SaveBlock", func(b *testing.B) {
 		store := memory.NewInMemoryAggregatorStore()
 		avsAddress := "0xtest"
 		chain := config.ChainId(1)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_ = store.SetLastProcessedBlock(ctx, avsAddress, chain, uint64(i))
+			blockRecord := &storage.BlockRecord{
+				Number:     uint64(i),
+				Hash:       fmt.Sprintf("0xhash%d", i),
+				ParentHash: fmt.Sprintf("0xhash%d", i-1),
+				Timestamp:  uint64(1234567890 + i),
+				ChainId:    chain,
+			}
+			_ = store.SaveBlock(ctx, avsAddress, blockRecord)
 		}
 	})
 

--- a/ponos/pkg/aggregator/storage/badger/badger.go
+++ b/ponos/pkg/aggregator/storage/badger/badger.go
@@ -18,10 +18,10 @@ import (
 
 // Key prefixes for different data types
 const (
-	prefixChainBlock   = "lastblock:%s:%d" // avsAddress:chainId
 	prefixTask         = "task:%s"
 	prefixTaskByStatus = "taskstatus:%s:%s" // status:taskId
 	prefixBlock        = "block:%s:%d:%d"   // avsAddress:chainId:blockNumber
+	prefixLatestBlock  = "block:%s:%d"      // avsAddress:chainId
 )
 
 // BadgerAggregatorStore implements the AggregatorStore interface using BadgerDB
@@ -96,66 +96,52 @@ func (s *BadgerAggregatorStore) runGC() {
 	}
 }
 
-// GetLastProcessedBlock retrieves the last processed block for a chain for a specific AVS
-func (s *BadgerAggregatorStore) GetLastProcessedBlock(ctx context.Context, avsAddress string, chainId config.ChainId) (uint64, error) {
+// GetLastProcessedBlock retrieves the last processed block record for a chain for a specific AVS
+func (s *BadgerAggregatorStore) GetLastProcessedBlock(ctx context.Context, avsAddress string, chainId config.ChainId) (*storage.BlockRecord, error) {
 	s.mu.RLock()
 	if s.closed {
 		s.mu.RUnlock()
-		return 0, storage.ErrStoreClosed
+		return nil, storage.ErrStoreClosed
 	}
 	s.mu.RUnlock()
 
-	var blockNum uint64
-	key := fmt.Sprintf(prefixChainBlock, avsAddress, chainId)
+	var blockRecord *storage.BlockRecord
+	prefix := fmt.Sprintf(prefixLatestBlock, avsAddress, chainId)
 
 	err := s.db.View(func(txn *badgerv3.Txn) error {
-		item, err := txn.Get([]byte(key))
-		if err != nil {
-			if errors.Is(err, badgerv3.ErrKeyNotFound) {
-				return storage.ErrNotFound
+		opts := badgerv3.DefaultIteratorOptions
+		opts.Prefix = []byte(prefix)
+		opts.Reverse = true
+
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		it.Rewind()
+		if it.Valid() {
+			item := it.Item()
+
+			var record storage.BlockRecord
+			err := item.Value(func(val []byte) error {
+				return json.Unmarshal(val, &record)
+			})
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal block record: %w", err)
 			}
-			return err
-		}
 
-		return item.Value(func(val []byte) error {
-			return json.Unmarshal(val, &blockNum)
-		})
+			blockRecord = &record
+		}
+		return nil
 	})
 
 	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return 0, err
-		}
-		return 0, fmt.Errorf("failed to get last processed block: %w", err)
+		return nil, fmt.Errorf("failed to get last processed block: %w", err)
 	}
 
-	return blockNum, nil
-}
-
-// SetLastProcessedBlock updates the last processed block for a chain for a specific AVS
-func (s *BadgerAggregatorStore) SetLastProcessedBlock(ctx context.Context, avsAddress string, chainId config.ChainId, blockNum uint64) error {
-	s.mu.RLock()
-	if s.closed {
-		s.mu.RUnlock()
-		return storage.ErrStoreClosed
-	}
-	s.mu.RUnlock()
-
-	key := fmt.Sprintf(prefixChainBlock, avsAddress, chainId)
-	value, err := json.Marshal(blockNum)
-	if err != nil {
-		return fmt.Errorf("failed to marshal block number: %w", err)
+	if blockRecord == nil {
+		return nil, storage.ErrNotFound
 	}
 
-	err = s.db.Update(func(txn *badgerv3.Txn) error {
-		return txn.Set([]byte(key), value)
-	})
-
-	if err != nil {
-		return fmt.Errorf("failed to set last processed block: %w", err)
-	}
-
-	return nil
+	return blockRecord, nil
 }
 
 func (s *BadgerAggregatorStore) SavePendingTask(ctx context.Context, task *types.Task) error {

--- a/ponos/pkg/aggregator/storage/badger/badger_test.go
+++ b/ponos/pkg/aggregator/storage/badger/badger_test.go
@@ -71,7 +71,14 @@ func TestBadgerAggregatorStore_Persistence(t *testing.T) {
 
 		// Set last processed block
 		avsAddress := "0xtest"
-		err = store.SetLastProcessedBlock(ctx, avsAddress, config.ChainId(1), 12345)
+		blockRecord := &storage.BlockRecord{
+			Number:     12345,
+			Hash:       "0xhash12345",
+			ParentHash: "0xhash12344",
+			Timestamp:  1234567890,
+			ChainId:    config.ChainId(1),
+		}
+		err = store.SaveBlock(ctx, avsAddress, blockRecord)
 		require.NoError(t, err)
 
 		// Close store
@@ -92,9 +99,9 @@ func TestBadgerAggregatorStore_Persistence(t *testing.T) {
 
 		// Verify block number
 		avsAddress := "0xtest"
-		blockNum, err := store.GetLastProcessedBlock(ctx, avsAddress, config.ChainId(1))
+		blockRecord, err := store.GetLastProcessedBlock(ctx, avsAddress, config.ChainId(1))
 		require.NoError(t, err)
-		assert.Equal(t, uint64(12345), blockNum)
+		assert.Equal(t, uint64(12345), blockRecord.Number)
 	}
 }
 

--- a/ponos/pkg/aggregator/storage/storage.go
+++ b/ponos/pkg/aggregator/storage/storage.go
@@ -10,16 +10,12 @@ import (
 
 // AggregatorStore defines the interface for aggregator state persistence
 type AggregatorStore interface {
-	// Chain polling state management - namespaced by AVS address
-	GetLastProcessedBlock(ctx context.Context, avsAddress string, chainId config.ChainId) (uint64, error)
-	SetLastProcessedBlock(ctx context.Context, avsAddress string, chainId config.ChainId, blockNum uint64) error
+	GetLastProcessedBlock(ctx context.Context, avsAddress string, chainId config.ChainId) (*BlockRecord, error)
 
-	// Block history management for reorg detection
 	SaveBlock(ctx context.Context, avsAddress string, block *BlockRecord) error
 	GetBlock(ctx context.Context, avsAddress string, chainId config.ChainId, blockNumber uint64) (*BlockRecord, error)
 	DeleteBlock(ctx context.Context, avsAddress string, chainId config.ChainId, blockNumber uint64) error
 
-	// Task management
 	SavePendingTask(ctx context.Context, task *types.Task) error
 	GetTask(ctx context.Context, taskId string) (*types.Task, error)
 	ListPendingTasks(ctx context.Context) ([]*types.Task, error)
@@ -27,7 +23,6 @@ type AggregatorStore interface {
 	UpdateTaskStatus(ctx context.Context, taskId string, status TaskStatus) error
 	DeleteTask(ctx context.Context, taskId string) error
 
-	// Lifecycle management
 	Close() error
 }
 

--- a/ponos/pkg/chainPoller/EVMChainPoller/evmChainPoller.go
+++ b/ponos/pkg/chainPoller/EVMChainPoller/evmChainPoller.go
@@ -118,7 +118,7 @@ func (ecp *EVMChainPoller) Start(ctx context.Context) error {
 		}
 	}
 
-	if lastBlockRecord == nil || lastBlockRecord.Number > 0 {
+	if lastBlockRecord == nil {
 		return fmt.Errorf("last processed block must exist")
 	}
 
@@ -245,6 +245,8 @@ func (ecp *EVMChainPoller) processBlockLogs(ctx context.Context, block *ethereum
 		)
 		return nil, err
 	}
+
+	block.ChainId = ecp.config.ChainId
 
 	ecp.logger.Sugar().Infow("Block fetched with logs",
 		"latestBlockNum", block.Number.Value(),

--- a/ponos/pkg/executor/storage/badger/badger.go
+++ b/ponos/pkg/executor/storage/badger/badger.go
@@ -15,11 +15,8 @@ import (
 
 // Key prefixes for different data types
 const (
-	prefixPerformer      = "performer:%s"
-	prefixTask           = "task:%s"
-	prefixDeployment     = "deployment:%s"
-	prefixDeployByStatus = "deploystatus:%s:%s" // status:deploymentId
-	prefixProcessed      = "processed:%s"       // processed tasks
+	prefixPerformer = "performer:%s"
+	prefixProcessed = "processed:%s" // processed tasks
 )
 
 // BadgerExecutorStore implements the ExecutorStore interface using BadgerDB

--- a/ponos/pkg/executor/storage/storage.go
+++ b/ponos/pkg/executor/storage/storage.go
@@ -7,17 +7,14 @@ import (
 
 // ExecutorStore defines the interface for executor state persistence
 type ExecutorStore interface {
-	// Performer state management
 	SavePerformerState(ctx context.Context, performerId string, state *PerformerState) error
 	GetPerformerState(ctx context.Context, performerId string) (*PerformerState, error)
 	ListPerformerStates(ctx context.Context) ([]*PerformerState, error)
 	DeletePerformerState(ctx context.Context, performerId string) error
 
-	// Processed task tracking - prevents duplicate task processing
 	MarkTaskProcessed(ctx context.Context, taskId string) error
 	IsTaskProcessed(ctx context.Context, taskId string) (bool, error)
 
-	// Lifecycle management
 	Close() error
 }
 


### PR DESCRIPTION
## Consolidate Block Tracking to Single Source of Truth

  ### Changes:
  - Removed SetLastProcessedBlock API and lastObservedBlock field from EVMChainPoller
  - GetLastProcessedBlock now returns *BlockRecord (with hash, parent, timestamp) instead of just uint64
  - All block tracking now uses SaveBlock(BlockRecord) as the single source of truth

  ### Benefits:
  - Enables reliable reorg detection with full block metadata (hash, parent hash)
  - Atomic updates prevent partial state during failures