### PR TITLE
feat: adding pruning of tasks during a block cancellation

### DIFF
--- a/ponos/internal/tests/mailbox/mailbox_integration_test.go
+++ b/ponos/internal/tests/mailbox/mailbox_integration_test.go
@@ -125,7 +125,7 @@ func testL1MailboxForCurve(t *testing.T, curveType config.CurveType, networkTarg
 		pollerConfig,
 		imContractStore,
 		aggStore,
-		taskBlockContextManager.NewTaskBlockContextManager(context.Background(), l),
+		taskBlockContextManager.NewTaskBlockContextManager(context.Background(), aggStore, l),
 		l,
 	)
 

--- a/ponos/internal/tests/persistence/block_reorg_test.go
+++ b/ponos/internal/tests/persistence/block_reorg_test.go
@@ -312,7 +312,7 @@ func TestEVMChainPollerReorgDetection(t *testing.T) {
 				pollerConfig,
 				contractStore,
 				store,
-				taskBlockContextManager.NewTaskBlockContextManager(ctx, logger),
+				taskBlockContextManager.NewTaskBlockContextManager(ctx, store, logger),
 				logger,
 			)
 

--- a/ponos/pkg/aggregator/aggregator.go
+++ b/ponos/pkg/aggregator/aggregator.go
@@ -505,7 +505,7 @@ func (a *Aggregator) getChainPollers(supportedChains []config.ChainId, avsAddres
 			pollerConfig,
 			a.contractStore,
 			a.store,
-			taskBlockContextManager.NewTaskBlockContextManager(a.rootCtx, a.logger),
+			taskBlockContextManager.NewTaskBlockContextManager(a.rootCtx, a.store, a.logger),
 			a.logger,
 		)
 		chainPollers[chainId] = poller

--- a/ponos/pkg/contextManager/blockContextManager.go
+++ b/ponos/pkg/contextManager/blockContextManager.go
@@ -12,6 +12,7 @@ type IBlockContextManager interface {
 }
 
 type BlockContext struct {
-	Ctx    context.Context
-	Cancel context.CancelFunc
+	Ctx     context.Context
+	Cancel  context.CancelFunc
+	TaskIDs map[string]struct{}
 }

--- a/ponos/pkg/contextManager/taskBlockContextManager/taskBlockContextManager.go
+++ b/ponos/pkg/contextManager/taskBlockContextManager/taskBlockContextManager.go
@@ -26,7 +26,7 @@ func NewTaskBlockContextManager(parentCtx context.Context, store storage.Aggrega
 		parentCtx:       parentCtx,
 		store:           store,
 		logger:          logger.With(zap.String("component", "TaskBlockContextManager")),
-		cleanupInterval: 5 * time.Minute,
+		cleanupInterval: 15 * time.Minute,
 	}
 
 	go mgr.cleanupExpiredContexts()
@@ -120,12 +120,5 @@ func (bcm *TaskBlockContextManager) cleanupContexts() {
 
 	for _, blockNum := range blocksToRemove {
 		delete(bcm.blockContexts, blockNum)
-	}
-
-	if len(blocksToRemove) > 0 {
-		bcm.logger.Debug("Cleaned up expired/cancelled block contexts",
-			zap.Int("removedCount", len(blocksToRemove)),
-			zap.Int("remainingCount", len(bcm.blockContexts)),
-		)
 	}
 }

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -270,6 +271,16 @@ func (ts *TaskSession[SigT, CertT, PubKeyT]) Broadcast() (*CertT, error) {
 				)
 				return
 			}
+
+			if !strings.EqualFold(res.OperatorAddress, peer.OperatorAddress) {
+				ts.logger.Sugar().Errorw("Operator address mismatch in response",
+					zap.String("taskId", ts.Task.TaskId),
+					zap.String("expected", peer.OperatorAddress),
+					zap.String("claimed", res.OperatorAddress),
+				)
+				return
+			}
+
 			ts.logger.Sugar().Infow("received task result from executor",
 				zap.String("taskId", ts.Task.TaskId),
 				zap.String("operatorAddress", peer.OperatorAddress),


### PR DESCRIPTION
## Context Management for Blockchain Reorgs
### Changes
  - Added automatic task deletion from storage when blocks are cancelled during reorgs
  - Integrated context population for tasks recovered from storage using SourceBlockNumber

### Key Features
When blocks are orphaned, their contexts are cancelled and associated tasks are deleted from storage

### Extras
- Validating well-formed task submission in Executor
- Validating TaskResult in Aggregator has matching operatorAddress to the `peer` called
- Test coverage for task submission