### PR TITLE
feat: hgctl telemetry

### DIFF
--- a/.github/workflows/hgctl.yaml
+++ b/.github/workflows/hgctl.yaml
@@ -103,9 +103,11 @@ jobs:
           go-version: '1.23'
       
       - name: Build binaries for all platforms
+        env:
+          HGCTL_POSTHOG_API_KEY: ${{ secrets.HGCTL_POSTHOG_API_KEY }}
         run: |
           cd hgctl-go
-          
+
           # Get version
           VERSION=$(cat VERSION | tr -d '[:space:]')
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
@@ -113,31 +115,40 @@ jobs:
             VERSION="${VERSION#hgctl-}" # Remove hgctl- prefix from tag
           fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          
+
           # Build for all platforms
           mkdir -p ./release
-          
+
+          # Set ldflags with API key injection
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          LDFLAGS="-X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Version=$VERSION' -X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Commit=$COMMIT_HASH'"
+
+          # Add PostHog API key if available
+          if [ -n "${HGCTL_POSTHOG_API_KEY}" ]; then
+            LDFLAGS="$LDFLAGS -X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/telemetry.embeddedTelemetryApiKey=${HGCTL_POSTHOG_API_KEY}'"
+          fi
+
           # Linux AMD64
           GOOS=linux GOARCH=amd64 go build \
-            -ldflags "-X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Version=$VERSION' -X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Commit=$(git rev-parse --short HEAD)'" \
+            -ldflags "$LDFLAGS" \
             -o ./release/hgctl-linux-amd64 \
             ./cmd/hgctl
-          
+
           # Linux ARM64
           GOOS=linux GOARCH=arm64 go build \
-            -ldflags "-X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Version=$VERSION' -X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Commit=$(git rev-parse --short HEAD)'" \
+            -ldflags "$LDFLAGS" \
             -o ./release/hgctl-linux-arm64 \
             ./cmd/hgctl
-          
+
           # Darwin AMD64
           GOOS=darwin GOARCH=amd64 go build \
-            -ldflags "-X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Version=$VERSION' -X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Commit=$(git rev-parse --short HEAD)'" \
+            -ldflags "$LDFLAGS" \
             -o ./release/hgctl-darwin-amd64 \
             ./cmd/hgctl
-          
+
           # Darwin ARM64
           GOOS=darwin GOARCH=arm64 go build \
-            -ldflags "-X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Version=$VERSION' -X 'github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version.Commit=$(git rev-parse --short HEAD)'" \
+            -ldflags "$LDFLAGS" \
             -o ./release/hgctl-darwin-arm64 \
             ./cmd/hgctl
           

--- a/hgctl-go/cmd/hgctl/main.go
+++ b/hgctl-go/cmd/hgctl/main.go
@@ -2,16 +2,23 @@ package main
 
 import (
 	"context"
+	"log"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/commands"
+	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/config"
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/telemetry"
 )
 
 func main() {
-	telemetry.Init()
+	// Load config for telemetry initialization
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+	telemetry.Init(cfg)
 	defer telemetry.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/hgctl-go/cmd/hgctl/main.go
+++ b/hgctl-go/cmd/hgctl/main.go
@@ -13,7 +13,6 @@ import (
 )
 
 func main() {
-	// Load config for telemetry initialization
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		log.Fatal(err)

--- a/hgctl-go/go.mod
+++ b/hgctl-go/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/posthog/posthog-go v1.6.8
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.5
@@ -52,6 +53,7 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/hgctl-go/go.sum
+++ b/hgctl-go/go.sum
@@ -133,6 +133,8 @@ github.com/graph-gophers/graphql-go v1.3.0 h1:Eb9x/q6MFpCLz7jBCiP/WTxjSDrYLR1QY4
 github.com/graph-gophers/graphql-go v1.3.0/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/holiman/billy v0.0.0-20240216141850-2abb0c79d3c4 h1:X4egAf/gcS1zATw6wn4Ej8vjuVGxeHdan+bRb2ebyv4=
@@ -225,6 +227,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/posthog/posthog-go v1.6.8 h1:l5H05oKqiZbLYAjxrus3Rvj606bdEu+7EDAhKnSgU6I=
+github.com/posthog/posthog-go v1.6.8/go.mod h1:LcC1Nu4AgvV22EndTtrMXTy+7RGVC0MhChSw7Qk5XkY=
 github.com/prometheus/client_golang v1.12.0 h1:C+UIj/QWtmqY13Arb8kwMt5j34/0Z2iKamrJ+ryC0Gg=
 github.com/prometheus/client_golang v1.12.0/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.2.1-0.20210607210712-147c58e9608a h1:CmF68hwI0XsOQ5UwlBopMi2Ow4Pbg32akc4KIVCOm+Y=

--- a/hgctl-go/internal/commands/commands.go
+++ b/hgctl-go/internal/commands/commands.go
@@ -44,41 +44,32 @@ and deploy AVS artifacts including EigenRuntime specifications.`,
 			},
 		},
 		Before: middleware.ChainBeforeFuncs(
-			// First load config and context
 			func(c *cli.Context) error {
-				// Initialize logger early for debugging
 				verbose := c.Bool("verbose")
 				logger.InitGlobalLoggerWithWriter(verbose, c.App.Writer)
 				l := logger.GetLogger()
 
-				// Check if user is requesting help
 				for _, arg := range os.Args {
 					if arg == "--help" || arg == "-h" || arg == "help" {
-						// Set empty context for help display
 						c.Context = context.WithValue(c.Context, config.ConfigKey, &config.Config{})
 						c.Context = context.WithValue(c.Context, config.ContextKey, &config.Context{})
 						return nil
 					}
 				}
 
-				// Load config
 				cfg, err := config.LoadConfig()
 				if err != nil {
 					l.Error("Failed to load config", zap.Error(err))
-					// Create empty config if it doesn't exist
 					cfg = &config.Config{
 						Contexts: make(map[string]*config.Context),
 					}
 				}
 
-				// Get current context
 				currentCtx, err := config.GetCurrentContext()
 				if err != nil {
-					// Allow config commands to run without a context
 					if isConfigCommand(c) {
 						currentCtx = &config.Context{}
 					} else {
-						// Log helpful error message
 						l.Error("No context configured. Please create a context.")
 						fmt.Fprintf(os.Stderr, "\nError: No context configured\n\n")
 						fmt.Fprintf(os.Stderr, "To create a context, run:\n")
@@ -89,7 +80,6 @@ and deploy AVS artifacts including EigenRuntime specifications.`,
 					}
 				}
 
-				// Store in context
 				c.Context = context.WithValue(c.Context, config.ConfigKey, cfg)
 				c.Context = context.WithValue(c.Context, config.ContextKey, currentCtx)
 
@@ -125,61 +115,52 @@ func isConfigCommand(c *cli.Context) bool {
 	return cmd == "context" || cmd == "telemetry"
 }
 
-// GetCommand returns the get command
 func GetCommand() *cli.Command {
 	cmd := get.Command()
 	cmd.Before = middleware.RequireContext
 	return cmd
 }
 
-// DescribeCommand returns the describe command
 func DescribeCommand() *cli.Command {
 	cmd := describe.Command()
 	cmd.Before = middleware.RequireContext
 	return cmd
 }
 
-// DeployCommand returns the deploy command
 func DeployCommand() *cli.Command {
 	cmd := deploy.Command()
 	cmd.Before = middleware.RequireContext
 	return cmd
 }
 
-// RemoveCommand returns the remove command
 func RemoveCommand() *cli.Command {
 	cmd := remove.Command()
 	cmd.Before = middleware.RequireContext
 	return cmd
 }
 
-// ContextCommand returns the context command
 func ContextCommand() *cli.Command {
 	return contextcmd.Command()
 }
 
-// KeystoreCommand returns the keystore command
 func KeystoreCommand() *cli.Command {
 	cmd := keystore.Command()
 	cmd.Before = middleware.RequireContext
 	return cmd
 }
 
-// SignerCommand returns the web3signer command
 func SignerCommand() *cli.Command {
 	cmd := signer.Command()
 	cmd.Before = middleware.RequireContext
 	return cmd
 }
 
-// EigenLayerCommand returns the eigenlayer command with all subcommands
 func EigenLayerCommand() *cli.Command {
 	cmd := eigenlayer.Command()
 	cmd.Before = middleware.RequireContext
 	return cmd
 }
 
-// TelemetryCommand returns the telemetry command
 func TelemetryCommand() *cli.Command {
 	return telemetry.Command()
 }

--- a/hgctl-go/internal/commands/middleware/context.go
+++ b/hgctl-go/internal/commands/middleware/context.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/config"
 	"github.com/urfave/cli/v2"
 )

--- a/hgctl-go/internal/commands/signer/signer.go
+++ b/hgctl-go/internal/commands/signer/signer.go
@@ -19,28 +19,28 @@ import (
 
 var (
 	titleStyle = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(lipgloss.Color("#7D56F4")).
-			MarginBottom(1)
+		Bold(true).
+		Foreground(lipgloss.Color("#7D56F4")).
+		MarginBottom(1)
 
 	selectedStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#7D56F4")).
-			Bold(true)
+		Foreground(lipgloss.Color("#7D56F4")).
+		Bold(true)
 
 	successStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#04B575")).
-			Bold(true)
+		Foreground(lipgloss.Color("#04B575")).
+		Bold(true)
 
 	helpStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#999999"))
+		Foreground(lipgloss.Color("#999999"))
 
 	warningStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FFFF00")).
-			Bold(true)
+		Foreground(lipgloss.Color("#FFFF00")).
+		Bold(true)
 
 	errorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FF0000")).
-			Bold(true)
+		Foreground(lipgloss.Color("#FF0000")).
+		Bold(true)
 )
 
 // expandPath expands ~ to the user's home directory and returns absolute path
@@ -358,11 +358,15 @@ func (m signerWizardModel) handleEnter() (tea.Model, tea.Cmd) {
 				m.stage = stageConfirm
 			case "keystore":
 				// Check if there are existing keystores of the right type
-				items := m.getExistingKeystores()
+				items, err := m.getExistingKeystores()
+				if err != nil {
+					m.err = fmt.Errorf("could not get existing keystores: %w", err)
+					return m, tea.Quit
+				}
 				if len(items) == 0 {
 					// No keystores found, show error and exit
 					curveType := strings.ToUpper(m.keyType)
-					m.err = fmt.Errorf("No %s keystores found in context. Use 'hgctl keystore create' to add one first.", curveType)
+					m.err = fmt.Errorf("no %s keystores found in context. Use 'hgctl keystore create' to add one first", curveType)
 					return m, tea.Quit
 				}
 				// Show list of existing keystores
@@ -531,9 +535,12 @@ func (m signerWizardModel) getSignerTypeItems() []list.Item {
 	}
 }
 
-func (m signerWizardModel) getExistingKeystores() []list.Item {
+func (m signerWizardModel) getExistingKeystores() ([]list.Item, error) {
 	var items []list.Item
-	cfg, _ := config.LoadConfig()
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return items, err
+	}
 	ctx := cfg.Contexts[m.contextName]
 
 	for _, ks := range ctx.Keystores {
@@ -543,7 +550,7 @@ func (m signerWizardModel) getExistingKeystores() []list.Item {
 			items = append(items, keystoreItem{ks.Name, ks.Path})
 		}
 	}
-	return items
+	return items, nil
 }
 
 func (m signerWizardModel) View() string {

--- a/hgctl-go/internal/commands/signer/signer.go
+++ b/hgctl-go/internal/commands/signer/signer.go
@@ -19,28 +19,28 @@ import (
 
 var (
 	titleStyle = lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("#7D56F4")).
-		MarginBottom(1)
+			Bold(true).
+			Foreground(lipgloss.Color("#7D56F4")).
+			MarginBottom(1)
 
 	selectedStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#7D56F4")).
-		Bold(true)
+			Foreground(lipgloss.Color("#7D56F4")).
+			Bold(true)
 
 	successStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#04B575")).
-		Bold(true)
+			Foreground(lipgloss.Color("#04B575")).
+			Bold(true)
 
 	helpStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#999999"))
+			Foreground(lipgloss.Color("#999999"))
 
 	warningStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#FFFF00")).
-		Bold(true)
+			Foreground(lipgloss.Color("#FFFF00")).
+			Bold(true)
 
 	errorStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#FF0000")).
-		Bold(true)
+			Foreground(lipgloss.Color("#FF0000")).
+			Bold(true)
 )
 
 // expandPath expands ~ to the user's home directory and returns absolute path

--- a/hgctl-go/internal/commands/telemetry/telemetry.go
+++ b/hgctl-go/internal/commands/telemetry/telemetry.go
@@ -1,0 +1,402 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/config"
+	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/output"
+	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/telemetry"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	titleStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#7D56F4")).
+			MarginBottom(1)
+
+	successStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#04B575")).
+			Bold(true)
+
+	helpStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#999999"))
+
+	infoStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#00BFFF"))
+)
+
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:  "telemetry",
+		Usage: "Configure telemetry settings",
+		Description: `Configure telemetry settings for hgctl.
+
+Telemetry helps improve hgctl by collecting anonymous usage data.
+All data is privacy-preserving and you maintain full control.`,
+		Subcommands: []*cli.Command{
+			{
+				Name:   "enable",
+				Usage:  "Enable telemetry with full data collection",
+				Action: enableTelemetry,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name:  "anonymous",
+						Usage: "Enable telemetry without operator address tracking",
+					},
+				},
+			},
+			{
+				Name:   "disable",
+				Usage:  "Disable telemetry completely",
+				Action: disableTelemetry,
+			},
+			{
+				Name:   "status",
+				Usage:  "Show current telemetry configuration",
+				Action: showStatus,
+			},
+			{
+				Name:    "configure",
+				Aliases: []string{"config"},
+				Usage:   "Configure telemetry interactively",
+				Action:  telemetryWizard,
+			},
+		},
+		Action: telemetryWizard, // Default to wizard if no subcommand
+	}
+}
+
+// enableTelemetry enables telemetry with optional anonymous mode
+func enableTelemetry(c *cli.Context) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	anonymous := c.Bool("anonymous")
+	enabled := true
+	cfg.TelemetryEnabled = &enabled
+	cfg.TelemetryAnonymous = anonymous
+
+	// Track telemetry enablement
+	telemetry.TrackEvent("telemetry_enabled", map[string]interface{}{
+		"anonymous": anonymous,
+	})
+
+	if err := config.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	if anonymous {
+		fmt.Println(successStyle.Render("✓ Telemetry enabled (anonymous mode)"))
+		fmt.Println(infoStyle.Render("  • Usage data will be collected"))
+		fmt.Println(infoStyle.Render("  • Operator address will NOT be tracked"))
+		fmt.Println(infoStyle.Render("  • All data is anonymized"))
+	} else {
+		fmt.Println(successStyle.Render("✓ Telemetry enabled"))
+		fmt.Println(infoStyle.Render("  • Usage data will be collected"))
+		fmt.Println(infoStyle.Render("  • Operator address will be included for better insights"))
+		fmt.Println(infoStyle.Render("  • All data is privacy-preserving"))
+	}
+
+	return nil
+}
+
+// disableTelemetry disables telemetry completely
+func disableTelemetry(c *cli.Context) error {
+	// Track telemetry disablement before disabling
+	telemetry.TrackEvent("telemetry_disabled", map[string]interface{}{})
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	disabled := false
+	cfg.TelemetryEnabled = &disabled
+
+	if err := config.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	fmt.Println(successStyle.Render("✓ Telemetry disabled"))
+	fmt.Println(helpStyle.Render("  No data will be collected"))
+
+	return nil
+}
+
+// showStatus displays the current telemetry configuration
+func showStatus(c *cli.Context) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	outputFormat := c.String("output")
+
+	// Determine telemetry status
+	status := "Disabled"
+	mode := "N/A"
+
+	if cfg.TelemetryEnabled != nil && *cfg.TelemetryEnabled {
+		status = "Enabled"
+
+		if cfg.TelemetryAnonymous {
+			mode = "Anonymous"
+		} else {
+			mode = "Full"
+		}
+	}
+
+	// Check for API key
+	hasAPIKey := cfg.PostHogAPIKey != ""
+	apiKeyStatus := "Not configured"
+	if hasAPIKey {
+		apiKeyStatus = "Configured"
+	}
+
+	data := map[string]interface{}{
+		"status":   status,
+		"mode":     mode,
+		"api_key":  apiKeyStatus,
+		"endpoint": "https://us.i.posthog.com",
+	}
+
+	// Add environment variable overrides if present
+	envOverrides := make(map[string]string)
+	if envEnabled := getEnvVar("HGCTL_TELEMETRY_ENABLED"); envEnabled != "" {
+		envOverrides["HGCTL_TELEMETRY_ENABLED"] = envEnabled
+	}
+	if envKey := getEnvVar("HGCTL_POSTHOG_KEY"); envKey != "" {
+		envOverrides["HGCTL_POSTHOG_KEY"] = "***configured***"
+	}
+	if envEndpoint := getEnvVar("HGCTL_POSTHOG_ENDPOINT"); envEndpoint != "" {
+		envOverrides["HGCTL_POSTHOG_ENDPOINT"] = envEndpoint
+	}
+
+	if len(envOverrides) > 0 {
+		data["env_overrides"] = envOverrides
+	}
+
+	// Use formatter to output the data
+	formatter := output.NewFormatter(outputFormat)
+	return formatter.Print(data)
+}
+
+// telemetryWizard runs an interactive wizard for configuring telemetry
+func telemetryWizard(c *cli.Context) error {
+	// If args provided, show help
+	if c.Args().Present() {
+		return cli.ShowCommandHelp(c, "telemetry")
+	}
+
+	fmt.Println(titleStyle.Render("📊 Telemetry Configuration"))
+	fmt.Println()
+	fmt.Println("Telemetry helps us improve hgctl by understanding how it's used.")
+	fmt.Println("All data collected is privacy-preserving and you have full control.")
+	fmt.Println()
+
+	model := newTelemetryWizardModel()
+	program := tea.NewProgram(model)
+
+	finalModel, err := program.Run()
+	if err != nil {
+		return fmt.Errorf("failed to run wizard: %w", err)
+	}
+
+	// Check if user completed the wizard
+	if m, ok := finalModel.(telemetryWizardModel); ok {
+		if m.completed {
+			return applyTelemetryConfig(m.choice)
+		}
+		if m.cancelled {
+			fmt.Println(helpStyle.Render("Configuration cancelled"))
+			return nil
+		}
+	}
+
+	return nil
+}
+
+// telemetryWizardModel is the model for the telemetry configuration wizard
+type telemetryWizardModel struct {
+	list      list.Model
+	choice    telemetryChoice
+	width     int
+	height    int
+	completed bool
+	cancelled bool
+}
+
+type telemetryChoice string
+
+const (
+	choiceEnableFull      telemetryChoice = "enable_full"
+	choiceEnableAnonymous telemetryChoice = "enable_anonymous"
+	choiceDisable         telemetryChoice = "disable"
+)
+
+// telemetryItem represents a telemetry configuration option
+type telemetryItem struct {
+	title       string
+	description string
+	choice      telemetryChoice
+}
+
+func (i telemetryItem) Title() string       { return i.title }
+func (i telemetryItem) Description() string { return i.description }
+func (i telemetryItem) FilterValue() string { return i.title }
+
+func newTelemetryWizardModel() telemetryWizardModel {
+	items := []list.Item{
+		telemetryItem{
+			title:       "Enable Telemetry",
+			description: "Collect usage data including operator address for better insights",
+			choice:      choiceEnableFull,
+		},
+		telemetryItem{
+			title:       "Enable Anonymous Telemetry",
+			description: "Collect usage data WITHOUT operator address (fully anonymous)",
+			choice:      choiceEnableAnonymous,
+		},
+		telemetryItem{
+			title:       "Disable Telemetry",
+			description: "Do not collect any data",
+			choice:      choiceDisable,
+		},
+	}
+
+	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Choose telemetry configuration:"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+
+	return telemetryWizardModel{
+		list: l,
+	}
+}
+
+func (m telemetryWizardModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m telemetryWizardModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.list.SetSize(msg.Width, msg.Height-4)
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			m.cancelled = true
+			return m, tea.Quit
+
+		case tea.KeyEnter:
+			if item, ok := m.list.SelectedItem().(telemetryItem); ok {
+				m.choice = item.choice
+				m.completed = true
+				return m, tea.Quit
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m telemetryWizardModel) View() string {
+	if m.completed || m.cancelled {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(m.list.View())
+	b.WriteString("\n\n")
+	b.WriteString(helpStyle.Render("Use ↑/↓ to navigate, Enter to select, Esc to cancel"))
+	return b.String()
+}
+
+// applyTelemetryConfig applies the selected telemetry configuration
+func applyTelemetryConfig(choice telemetryChoice) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	switch choice {
+	case choiceEnableFull:
+		enabled := true
+		cfg.TelemetryEnabled = &enabled
+		cfg.TelemetryAnonymous = false
+
+		// Track telemetry enablement from wizard
+		telemetry.TrackEvent("telemetry_enabled", map[string]interface{}{
+			"anonymous": false,
+			"source":    "wizard",
+		})
+
+		fmt.Println()
+		fmt.Println(successStyle.Render("✓ Telemetry enabled"))
+		fmt.Println(infoStyle.Render("  • Usage data will be collected"))
+		fmt.Println(infoStyle.Render("  • Operator address will be included for better insights"))
+		fmt.Println(infoStyle.Render("  • All data is privacy-preserving"))
+		fmt.Println()
+		fmt.Println(helpStyle.Render("To disable telemetry later, run: hgctl telemetry disable"))
+
+	case choiceEnableAnonymous:
+		enabled := true
+		cfg.TelemetryEnabled = &enabled
+		cfg.TelemetryAnonymous = true
+
+		// Track anonymous telemetry enablement from wizard
+		telemetry.TrackEvent("telemetry_enabled", map[string]interface{}{
+			"anonymous": true,
+			"source":    "wizard",
+		})
+
+		fmt.Println()
+		fmt.Println(successStyle.Render("✓ Telemetry enabled (anonymous mode)"))
+		fmt.Println(infoStyle.Render("  • Usage data will be collected"))
+		fmt.Println(infoStyle.Render("  • Operator address will NOT be tracked"))
+		fmt.Println(infoStyle.Render("  • All data is anonymized"))
+		fmt.Println()
+		fmt.Println(helpStyle.Render("To change settings later, run: hgctl telemetry configure"))
+
+	case choiceDisable:
+		// Track telemetry disablement from wizard before disabling
+		telemetry.TrackEvent("telemetry_disabled", map[string]interface{}{
+			"source": "wizard",
+		})
+
+		disabled := false
+		cfg.TelemetryEnabled = &disabled
+
+		fmt.Println()
+		fmt.Println(successStyle.Render("✓ Telemetry disabled"))
+		fmt.Println(helpStyle.Render("  No data will be collected"))
+		fmt.Println()
+		fmt.Println(helpStyle.Render("To enable telemetry later, run: hgctl telemetry enable"))
+	}
+
+	if err := config.SaveConfig(cfg); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	return nil
+}
+
+// getEnvVar safely gets an environment variable
+func getEnvVar(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}

--- a/hgctl-go/internal/commands/telemetry/telemetry.go
+++ b/hgctl-go/internal/commands/telemetry/telemetry.go
@@ -62,18 +62,11 @@ All data is privacy-preserving and you maintain full control.`,
 				Usage:  "Show current telemetry configuration",
 				Action: showStatus,
 			},
-			{
-				Name:    "configure",
-				Aliases: []string{"config"},
-				Usage:   "Configure telemetry interactively",
-				Action:  telemetryWizard,
-			},
 		},
-		Action: telemetryWizard, // Default to wizard if no subcommand
+		Action: telemetryWizard,
 	}
 }
 
-// enableTelemetry enables telemetry with optional anonymous mode
 func enableTelemetry(c *cli.Context) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -85,7 +78,6 @@ func enableTelemetry(c *cli.Context) error {
 	cfg.TelemetryEnabled = &enabled
 	cfg.TelemetryAnonymous = anonymous
 
-	// Track telemetry enablement
 	telemetry.TrackEvent("telemetry_enabled", map[string]interface{}{
 		"anonymous": anonymous,
 	})
@@ -109,9 +101,7 @@ func enableTelemetry(c *cli.Context) error {
 	return nil
 }
 
-// disableTelemetry disables telemetry completely
 func disableTelemetry(c *cli.Context) error {
-	// Track telemetry disablement before disabling
 	telemetry.TrackEvent("telemetry_disabled", map[string]interface{}{})
 
 	cfg, err := config.LoadConfig()
@@ -132,7 +122,6 @@ func disableTelemetry(c *cli.Context) error {
 	return nil
 }
 
-// showStatus displays the current telemetry configuration
 func showStatus(c *cli.Context) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -141,7 +130,6 @@ func showStatus(c *cli.Context) error {
 
 	outputFormat := c.String("output")
 
-	// Determine telemetry status
 	status := "Disabled"
 	mode := "N/A"
 
@@ -155,7 +143,6 @@ func showStatus(c *cli.Context) error {
 		}
 	}
 
-	// Check for API key
 	hasAPIKey := cfg.PostHogAPIKey != ""
 	apiKeyStatus := "Not configured"
 	if hasAPIKey {
@@ -185,14 +172,11 @@ func showStatus(c *cli.Context) error {
 		data["env_overrides"] = envOverrides
 	}
 
-	// Use formatter to output the data
 	formatter := output.NewFormatter(outputFormat)
 	return formatter.Print(data)
 }
 
-// telemetryWizard runs an interactive wizard for configuring telemetry
 func telemetryWizard(c *cli.Context) error {
-	// If args provided, show help
 	if c.Args().Present() {
 		return cli.ShowCommandHelp(c, "telemetry")
 	}
@@ -211,7 +195,6 @@ func telemetryWizard(c *cli.Context) error {
 		return fmt.Errorf("failed to run wizard: %w", err)
 	}
 
-	// Check if user completed the wizard
 	if m, ok := finalModel.(telemetryWizardModel); ok {
 		if m.completed {
 			return applyTelemetryConfig(m.choice)
@@ -225,7 +208,6 @@ func telemetryWizard(c *cli.Context) error {
 	return nil
 }
 
-// telemetryWizardModel is the model for the telemetry configuration wizard
 type telemetryWizardModel struct {
 	list      list.Model
 	choice    telemetryChoice
@@ -243,7 +225,6 @@ const (
 	choiceDisable         telemetryChoice = "disable"
 )
 
-// telemetryItem represents a telemetry configuration option
 type telemetryItem struct {
 	title       string
 	description string
@@ -327,7 +308,6 @@ func (m telemetryWizardModel) View() string {
 	return b.String()
 }
 
-// applyTelemetryConfig applies the selected telemetry configuration
 func applyTelemetryConfig(choice telemetryChoice) error {
 	cfg, err := config.LoadConfig()
 	if err != nil {
@@ -340,7 +320,6 @@ func applyTelemetryConfig(choice telemetryChoice) error {
 		cfg.TelemetryEnabled = &enabled
 		cfg.TelemetryAnonymous = false
 
-		// Track telemetry enablement from wizard
 		telemetry.TrackEvent("telemetry_enabled", map[string]interface{}{
 			"anonymous": false,
 			"source":    "wizard",
@@ -374,7 +353,6 @@ func applyTelemetryConfig(choice telemetryChoice) error {
 		fmt.Println(helpStyle.Render("To change settings later, run: hgctl telemetry configure"))
 
 	case choiceDisable:
-		// Track telemetry disablement from wizard before disabling
 		telemetry.TrackEvent("telemetry_disabled", map[string]interface{}{
 			"source": "wizard",
 		})
@@ -396,7 +374,6 @@ func applyTelemetryConfig(choice telemetryChoice) error {
 	return nil
 }
 
-// getEnvVar safely gets an environment variable
 func getEnvVar(key string) string {
 	return strings.TrimSpace(os.Getenv(key))
 }

--- a/hgctl-go/internal/config/config.go
+++ b/hgctl-go/internal/config/config.go
@@ -4,26 +4,30 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/client"
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/logger"
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/signer"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"gopkg.in/yaml.v3"
-	"os"
-	"path/filepath"
 )
 
 // Define custom types for context keys to avoid collisions
 type contextKey string
 
 var (
-	ContextKey        contextKey = "currentContext"
-	ConfigKey         contextKey = "config"
-	EnvKey            contextKey = "env"
-	ContractClientKey contextKey = "contractClient"
-	LoggerKey         contextKey = "loggerKey"
-	KeystoreName      string     = "KEYSTORE_NAME"
-	KeystorePassword  string     = "KEYSTORE_PASSWORD"
+	ContextKey          contextKey = "currentContext"
+	ConfigKey           contextKey = "config"
+	EnvKey              contextKey = "env"
+	ContractClientKey   contextKey = "contractClient"
+	LoggerKey           contextKey = "loggerKey"
+	TelemetryContextKey contextKey = "telemetryContextKey"
+	MetricsContextKey   contextKey = "metricsContextKey"
+
+	KeystoreName     string = "KEYSTORE_NAME"
+	KeystorePassword string = "KEYSTORE_PASSWORD"
 )
 
 type ContractOverrides struct {
@@ -65,8 +69,11 @@ type Context struct {
 }
 
 type Config struct {
-	CurrentContext string              `yaml:"currentContext"`
-	Contexts       map[string]*Context `yaml:"contexts"`
+	CurrentContext     string              `yaml:"currentContext"`
+	Contexts           map[string]*Context `yaml:"contexts"`
+	TelemetryEnabled   *bool               `yaml:"telemetryEnabled,omitempty"`
+	TelemetryAnonymous bool                `yaml:"telemetryAnonymous,omitempty"`
+	PostHogAPIKey      string              `yaml:"posthogApiKey,omitempty"`
 }
 
 // OperatorSignerFromContext loads the operator key signer from context

--- a/hgctl-go/internal/telemetry/client.go
+++ b/hgctl-go/internal/telemetry/client.go
@@ -1,0 +1,11 @@
+package telemetry
+
+import (
+	"context"
+)
+
+type Client interface {
+	Track(ctx context.Context, event string, properties map[string]interface{}) error
+	AddMetric(ctx context.Context, metric Metric) error
+	Close() error
+}

--- a/hgctl-go/internal/telemetry/metric.go
+++ b/hgctl-go/internal/telemetry/metric.go
@@ -1,0 +1,61 @@
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/config"
+)
+
+type MetricsContext struct {
+	StartTime  time.Time         `json:"start_time"`
+	Metrics    []Metric          `json:"metrics"`
+	Properties map[string]string `json:"properties"`
+}
+
+type Metric struct {
+	Value      float64           `json:"value"`
+	Name       string            `json:"name"`
+	Dimensions map[string]string `json:"dimensions"`
+}
+
+func WithMetricsContext(ctx context.Context, metrics *MetricsContext) context.Context {
+	return context.WithValue(ctx, config.MetricsContextKey, metrics)
+}
+
+func MetricsFromContext(ctx context.Context) (*MetricsContext, error) {
+	metrics, ok := ctx.Value(config.MetricsContextKey).(*MetricsContext)
+	if !ok || metrics == nil {
+		return nil, errors.New("no metrics context found")
+	}
+	return metrics, nil
+}
+
+func NewMetricsContext() *MetricsContext {
+	return &MetricsContext{
+		StartTime:  time.Now(),
+		Metrics:    make([]Metric, 0),
+		Properties: make(map[string]string),
+	}
+}
+
+func (m *MetricsContext) AddMetric(name string, value float64) {
+	m.AddMetricWithDimensions(name, value, make(map[string]string))
+}
+
+func (m *MetricsContext) AddMetricWithDimensions(name string, value float64, dimensions map[string]string) {
+	m.Metrics = append(m.Metrics, Metric{
+		Name:       name,
+		Value:      value,
+		Dimensions: dimensions,
+	})
+}
+
+func (m *MetricsContext) AddProperty(key, value string) {
+	m.Properties[key] = value
+}
+
+func (m *MetricsContext) Duration() time.Duration {
+	return time.Since(m.StartTime)
+}

--- a/hgctl-go/internal/telemetry/noop.go
+++ b/hgctl-go/internal/telemetry/noop.go
@@ -1,0 +1,26 @@
+package telemetry
+
+import "context"
+
+type NoopClient struct{}
+
+func NewNoopClient() *NoopClient {
+	return &NoopClient{}
+}
+
+func (c *NoopClient) Track(_ context.Context, _ string, _ map[string]interface{}) error {
+	return nil
+}
+
+func (c *NoopClient) AddMetric(_ context.Context, _ Metric) error {
+	return nil
+}
+
+func (c *NoopClient) Close() error {
+	return nil
+}
+
+func IsNoopClient(client Client) bool {
+	_, isNoop := client.(*NoopClient)
+	return isNoop
+}

--- a/hgctl-go/internal/telemetry/posthog.go
+++ b/hgctl-go/internal/telemetry/posthog.go
@@ -24,7 +24,6 @@ func NewPostHogClient(cfg *config.Config, namespace string) (*PostHogClient, err
 
 	apiKey := getPostHogAPIKey(cfg)
 	if apiKey == "" {
-		// No API key available, return nil without error
 		return nil, nil
 	}
 
@@ -38,7 +37,6 @@ func NewPostHogClient(cfg *config.Config, namespace string) (*PostHogClient, err
 	distinctID := getAnonymousID()
 
 	var operatorAddress string
-	// Only include operator address if not in anonymous mode
 	if cfg != nil && !cfg.TelemetryAnonymous && cfg.CurrentContext != "" {
 		if ctx, ok := cfg.Contexts[cfg.CurrentContext]; ok && ctx.OperatorAddress != "" {
 			operatorAddress = ctx.OperatorAddress

--- a/hgctl-go/internal/telemetry/posthog.go
+++ b/hgctl-go/internal/telemetry/posthog.go
@@ -1,0 +1,138 @@
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/config"
+	"github.com/posthog/posthog-go"
+)
+
+type PostHogClient struct {
+	namespace       string
+	client          posthog.Client
+	distinctID      string
+	operatorAddress string
+	enabled         bool
+}
+
+func NewPostHogClient(cfg *config.Config, namespace string) (*PostHogClient, error) {
+	if !isTelemetryEnabled(cfg) {
+		return nil, nil
+	}
+
+	apiKey := getPostHogAPIKey(cfg)
+	if apiKey == "" {
+		// No API key available, return nil without error
+		return nil, nil
+	}
+
+	client, err := posthog.NewWithConfig(apiKey, posthog.Config{
+		Endpoint: getPostHogEndpoint(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	distinctID := getAnonymousID()
+
+	var operatorAddress string
+	// Only include operator address if not in anonymous mode
+	if cfg != nil && !cfg.TelemetryAnonymous && cfg.CurrentContext != "" {
+		if ctx, ok := cfg.Contexts[cfg.CurrentContext]; ok && ctx.OperatorAddress != "" {
+			operatorAddress = ctx.OperatorAddress
+		}
+	}
+
+	return &PostHogClient{
+		namespace:       namespace,
+		client:          client,
+		distinctID:      distinctID,
+		operatorAddress: operatorAddress,
+		enabled:         true,
+	}, nil
+}
+
+func (c *PostHogClient) Track(_ context.Context, event string, properties map[string]interface{}) error {
+	if c == nil || c.client == nil || !c.enabled {
+		return nil
+	}
+
+	eventName := fmt.Sprintf("%s_%s", c.namespace, event)
+
+	if c.operatorAddress != "" {
+		properties["operator_address"] = c.operatorAddress
+	}
+
+	_ = c.client.Enqueue(posthog.Capture{
+		DistinctId: c.distinctID,
+		Event:      eventName,
+		Properties: properties,
+	})
+	return nil
+}
+
+func (c *PostHogClient) AddMetric(_ context.Context, metric Metric) error {
+	if c == nil || c.client == nil || !c.enabled {
+		return nil
+	}
+
+	props := make(map[string]interface{})
+	props["metric_name"] = metric.Name
+	props["metric_value"] = metric.Value
+
+	if c.operatorAddress != "" {
+		props["operator_address"] = c.operatorAddress
+	}
+
+	for k, v := range metric.Dimensions {
+		props[k] = v
+	}
+
+	_ = c.client.Enqueue(posthog.Capture{
+		DistinctId: c.distinctID,
+		Event:      fmt.Sprintf("%s_metric", c.namespace),
+		Properties: props,
+	})
+	return nil
+}
+
+func (c *PostHogClient) Close() error {
+	if c == nil || c.client == nil {
+		return nil
+	}
+	_ = c.client.Close()
+	return nil
+}
+
+func isTelemetryEnabled(cfg *config.Config) bool {
+	if envVal := os.Getenv("HGCTL_TELEMETRY_ENABLED"); envVal != "" {
+		return envVal == "true" || envVal == "1"
+	}
+
+	if cfg != nil && cfg.TelemetryEnabled != nil {
+		return *cfg.TelemetryEnabled
+	}
+
+	return false
+}
+
+func getPostHogAPIKey(cfg *config.Config) string {
+	if key := os.Getenv("HGCTL_POSTHOG_KEY"); key != "" {
+		return key
+	}
+
+	if cfg != nil && cfg.PostHogAPIKey != "" {
+		return cfg.PostHogAPIKey
+	}
+
+	return embeddedTelemetryApiKey
+}
+
+func getPostHogEndpoint() string {
+	if endpoint := os.Getenv("HGCTL_POSTHOG_ENDPOINT"); endpoint != "" {
+		return endpoint
+	}
+	return "https://us.i.posthog.com"
+}

--- a/hgctl-go/internal/telemetry/telemetry.go
+++ b/hgctl-go/internal/telemetry/telemetry.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/config"
 	"github.com/Layr-Labs/hourglass-monorepo/hgctl-go/internal/version"
 	"github.com/denisbrodbeck/machineid"
-	"github.com/spf13/cobra"
 	"github.com/urfave/cli/v2"
 )
 
@@ -27,36 +26,6 @@ func Init(cfg *config.Config) {
 		globalClient = NewNoopClient()
 	} else {
 		globalClient = client
-	}
-}
-
-func TrackCommand(cmd *cobra.Command, startTime time.Time) func() {
-	if globalClient == nil {
-		return func() {}
-	}
-
-	metricsCtx := NewMetricsContext()
-	metricsCtx.StartTime = startTime
-
-	return func() {
-		duration := time.Since(startTime).Milliseconds()
-
-		properties := map[string]interface{}{
-			"command":     getCommandPath(cmd),
-			"duration_ms": duration,
-			"version":     version.GetVersion(),
-			"commit":      version.GetCommit(),
-			"os":          runtime.GOOS,
-			"arch":        runtime.GOARCH,
-			"go_version":  runtime.Version(),
-			"success":     true,
-		}
-
-		if len(metricsCtx.Metrics) > 0 {
-			properties["metrics"] = metricsCtx.Metrics
-		}
-
-		_ = globalClient.Track(context.Background(), "command_executed", properties)
 	}
 }
 
@@ -81,7 +50,6 @@ func TrackCLICommand(c *cli.Context, commandName string, startTime time.Time) fu
 			"os":          runtime.GOOS,
 			"arch":        runtime.GOARCH,
 			"go_version":  runtime.Version(),
-			"success":     true, // Can be overridden if error occurred
 		}
 
 		if metrics, err := MetricsFromContext(ctx); err == nil && len(metrics.Metrics) > 0 {
@@ -127,37 +95,10 @@ func TrackError(err error, context map[string]interface{}) {
 	TrackEvent("error_occurred", context)
 }
 
-func EmitMetric(ctx context.Context, name string, value float64, dimensions map[string]string) {
-	if metricsCtx, err := MetricsFromContext(ctx); err == nil {
-		metricsCtx.AddMetricWithDimensions(name, value, dimensions)
-	}
-
-	if globalClient != nil {
-		metric := Metric{
-			Name:       name,
-			Value:      value,
-			Dimensions: dimensions,
-		}
-		_ = globalClient.AddMetric(ctx, metric)
-	}
-}
-
 func Close() {
 	if globalClient != nil {
 		_ = globalClient.Close()
 	}
-}
-
-func getCommandPath(cmd *cobra.Command) string {
-	if cmd == nil {
-		return "root"
-	}
-
-	path := cmd.CommandPath()
-	if path == "" {
-		path = "root"
-	}
-	return path
 }
 
 func getAnonymousID() string {

--- a/hgctl-go/internal/version/version.go
+++ b/hgctl-go/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 var (
-	Version = "dev"
-	Commit  = "unknown"
+	Version string
+	Commit  string
 )
 
 func GetVersion() string {

--- a/ponos/go.mod
+++ b/ponos/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.0-alpha.6
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.70.0
 	google.golang.org/protobuf v1.36.6
@@ -111,7 +112,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.35.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.35.0 // indirect
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
-	go.uber.org/mock v0.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/exp v0.0.0-20240325151524-a685a6edb6d8 // indirect

--- a/ponos/go.sum
+++ b/ponos/go.sum
@@ -489,8 +489,6 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
-golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -525,9 +523,8 @@ golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.33.0 h1:4qz2S3zmRxbGIhDIAgjxvFutSvH5EfnsYrRBj0UI0bc=
-golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
 golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
+golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Summary

  - Added telemetry module to hgctl for anonymous usage tracking via PostHog
  - Implemented telemetry command with wizard interface for enable/disable/configure options
  - Added anonymous mode to collect metrics without operator addresses for privacy

### Key Features

  - PostHog client integration with opt-in telemetry (disabled by default)
  - Interactive wizard and headless CLI modes for configuration
  - Anonymous mode flag (TelemetryAnonymous) stored separately from enabled state
  - Tracks telemetry configuration changes (enable/disable events)
  - Build-time API key injection via GitHub Actions
  - Middleware integration for automatic command tracking

### Implementation

  - Client interface pattern with PostHog and Noop implementations
  - Context-based metrics collection throughout command execution
  - Privacy-preserving anonymous IDs using hashed machine IDs
  - Operator address included as dimension only when not in anonymous mode
  - Clear separation of telemetry state (enabled/disabled) from mode (full/anonymous)