### PR TITLE
fix: address race condition on task session result chan

### DIFF
--- a/hgctl-go/internal/commands/middleware/middleware.go
+++ b/hgctl-go/internal/commands/middleware/middleware.go
@@ -70,7 +70,6 @@ func MiddlewareBeforeFunc(c *cli.Context) error {
 	return nil
 }
 
-
 func ExitErrHandler(c *cli.Context, err error) {
 	if err == nil {
 		return

--- a/hgctl-go/internal/commands/telemetry/telemetry.go
+++ b/hgctl-go/internal/commands/telemetry/telemetry.go
@@ -17,19 +17,19 @@ import (
 
 var (
 	titleStyle = lipgloss.NewStyle().
-		Bold(true).
-		Foreground(lipgloss.Color("#7D56F4")).
-		MarginBottom(1)
+			Bold(true).
+			Foreground(lipgloss.Color("#7D56F4")).
+			MarginBottom(1)
 
 	successStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#04B575")).
-		Bold(true)
+			Foreground(lipgloss.Color("#04B575")).
+			Bold(true)
 
 	helpStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#999999"))
+			Foreground(lipgloss.Color("#999999"))
 
 	infoStyle = lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#00BFFF"))
+			Foreground(lipgloss.Color("#00BFFF"))
 )
 
 func Command() *cli.Command {

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
-	"sync/atomic"
 
 	"github.com/Layr-Labs/crypto-libs/pkg/bn254"
 	"github.com/Layr-Labs/crypto-libs/pkg/ecdsa"
@@ -31,8 +29,6 @@ type TaskSession[SigT, CertT, PubKeyT any] struct {
 	signer              signer.ISigner
 	context             context.Context
 	logger              *zap.Logger
-	results             sync.Map
-	resultsCount        atomic.Uint32
 	operatorPeersWeight *operatorManager.PeerWeight
 	taskAggregator      aggregation.ITaskResultAggregator[SigT, CertT, PubKeyT]
 	aggregatorAddress   string
@@ -83,15 +79,12 @@ func NewBN254TaskSession(
 		Task:                task,
 		aggregatorAddress:   aggregatorAddress,
 		signer:              signer,
-		results:             sync.Map{},
 		context:             ctx,
 		logger:              logger,
 		taskAggregator:      ta,
 		operatorPeersWeight: operatorPeersWeight,
 		tlsEnabled:          tlsEnabled,
 	}
-
-	ts.resultsCount.Store(0)
 
 	return ts, nil
 }
@@ -139,15 +132,12 @@ func NewECDSATaskSession(
 		Task:                task,
 		aggregatorAddress:   aggregatorAddress,
 		signer:              signer,
-		results:             sync.Map{},
 		context:             ctx,
 		logger:              logger,
 		taskAggregator:      ta,
 		operatorPeersWeight: operatorPeersWeight,
 		tlsEnabled:          tlsEnabled,
 	}
-
-	ts.resultsCount.Store(0)
 
 	return ts, nil
 }

--- a/ponos/pkg/taskSession/taskSession.go
+++ b/ponos/pkg/taskSession/taskSession.go
@@ -256,6 +256,12 @@ func (ts *TaskSession[SigT, CertT, PubKeyT]) Broadcast() (*CertT, error) {
 
 			res, err := c.SubmitTask(submissionContext, taskSubmission)
 			if err != nil {
+
+				if err.Error() == context.Canceled.Error() {
+					ts.logger.Sugar().Infow("task session submission cancelled")
+					return
+				}
+
 				ts.logger.Sugar().Errorw("Failed to submit task to executor",
 					zap.String("executorAddress", peer.OperatorAddress),
 					zap.String("networkAddress", socket),

--- a/ponos/pkg/taskSession/taskSession_test.go
+++ b/ponos/pkg/taskSession/taskSession_test.go
@@ -236,7 +236,6 @@ func TestNewBN254TaskSession(t *testing.T) {
 		assert.Equal(t, "0xaggregator", session.aggregatorAddress)
 		assert.NotNil(t, session.signer)
 		assert.Equal(t, operatorPeersWeight, session.operatorPeersWeight)
-		assert.Equal(t, uint32(0), session.resultsCount.Load())
 	})
 
 	t.Run("invalid operator set", func(t *testing.T) {
@@ -479,7 +478,6 @@ func TestTaskSession_BasicFunctionality(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify initial state
-		assert.Equal(t, uint32(0), session.resultsCount.Load())
 		assert.NotNil(t, session.taskAggregator)
 		assert.Equal(t, task.TaskId, session.Task.TaskId)
 
@@ -511,7 +509,6 @@ func TestTaskSession_BasicFunctionality(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify initial state
-		assert.Equal(t, uint32(0), session.resultsCount.Load())
 		assert.NotNil(t, session.taskAggregator)
 		assert.Equal(t, task.TaskId, session.Task.TaskId)
 
@@ -574,8 +571,6 @@ func TestTaskSession_DeadlockScenario(t *testing.T) {
 			"Task aggregator should not have met signing threshold with insufficient responses")
 
 		// Verify initial state remained unchanged due to no successful responses
-		assert.Equal(t, uint32(0), session.resultsCount.Load(),
-			"Should have zero successful responses in complete deadlock")
 	})
 
 	t.Run("deadlock scenario with high threshold requirement", func(t *testing.T) {
@@ -643,9 +638,6 @@ func TestTaskSession_DeadlockScenario(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Store initial state
-		initialResultsCount := session.resultsCount.Load()
-
 		// Attempt process - should deadlock
 		cert, err := session.Process()
 
@@ -654,8 +646,6 @@ func TestTaskSession_DeadlockScenario(t *testing.T) {
 		require.Nil(t, cert)
 
 		// Verify internal state consistency during deadlock
-		assert.Equal(t, initialResultsCount, session.resultsCount.Load(),
-			"Results count should remain unchanged in complete deadlock")
 
 		// Verify the task session maintains proper state even in failure scenarios
 		assert.NotNil(t, session.Task, "Task should remain accessible")


### PR DESCRIPTION
## Summary
The task result chan has a racy situation currently when stopping result collection. This PR addresses this to make it thread safe and also cancels tasks when they will no longer be considered for submission (threshold is met).