### PR TITLE
chore: bump up middleware contracts

### DIFF
--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -1,0 +1,8 @@
+{
+  "contracts/lib/eigenlayer-middleware": {
+    "rev": "8f8cb97b3097dc5adbcba2db4b80073e4df3b9f8"
+  },
+  "contracts/lib/forge-std": {
+    "rev": "60acb7aaadcce2d68e52986a0a66fe79f07d138f"
+  }
+}

--- a/contracts/script/local/DeployAVSL1Contracts.s.sol
+++ b/contracts/script/local/DeployAVSL1Contracts.s.sol
@@ -8,6 +8,7 @@ import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transp
 
 import {IAllocationManager} from "@eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IKeyRegistrar} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+import {IPermissionController} from "@eigenlayer-contracts/src/contracts/interfaces/IPermissionController.sol";
 
 import {MockTaskAVSRegistrar} from "@eigenlayer-middleware/test/mocks/MockTaskAVSRegistrar.sol";
 import {ITaskAVSRegistrarBaseTypes} from "@eigenlayer-middleware/src/interfaces/ITaskAVSRegistrarBase.sol";
@@ -16,6 +17,7 @@ contract DeployAVSL1Contracts is Script {
     // Eigenlayer Core Contracts
     IAllocationManager public ALLOCATION_MANAGER = IAllocationManager(0x42583067658071247ec8CE0A516A58f682002d07);
     IKeyRegistrar public KEY_REGISTRAR = IKeyRegistrar(0xA4dB30D08d8bbcA00D40600bee9F029984dB162a);
+    IPermissionController public PERMISSION_CONTROLLER = IPermissionController(0x44632dfBdCb6D3E21EF613B0ca8A6A0c618F5a37);
 
     function setUp() public {}
 
@@ -43,7 +45,7 @@ contract DeployAVSL1Contracts is Script {
         console.log("ProxyAdmin deployed to:", address(proxyAdmin));
 
         // Deploy implementation
-        MockTaskAVSRegistrar taskAVSRegistrarImpl = new MockTaskAVSRegistrar(ALLOCATION_MANAGER, KEY_REGISTRAR);
+        MockTaskAVSRegistrar taskAVSRegistrarImpl = new MockTaskAVSRegistrar(ALLOCATION_MANAGER, KEY_REGISTRAR, PERMISSION_CONTROLLER);
         console.log("TaskAVSRegistrar implementation deployed to:", address(taskAVSRegistrarImpl));
 
         // Deploy proxy with initialization

--- a/contracts/script/local/DeployAVSL1Contracts.s.sol
+++ b/contracts/script/local/DeployAVSL1Contracts.s.sol
@@ -17,7 +17,8 @@ contract DeployAVSL1Contracts is Script {
     // Eigenlayer Core Contracts
     IAllocationManager public ALLOCATION_MANAGER = IAllocationManager(0x42583067658071247ec8CE0A516A58f682002d07);
     IKeyRegistrar public KEY_REGISTRAR = IKeyRegistrar(0xA4dB30D08d8bbcA00D40600bee9F029984dB162a);
-    IPermissionController public PERMISSION_CONTROLLER = IPermissionController(0x44632dfBdCb6D3E21EF613B0ca8A6A0c618F5a37);
+    IPermissionController public PERMISSION_CONTROLLER =
+        IPermissionController(0x44632dfBdCb6D3E21EF613B0ca8A6A0c618F5a37);
 
     function setUp() public {}
 
@@ -45,7 +46,8 @@ contract DeployAVSL1Contracts is Script {
         console.log("ProxyAdmin deployed to:", address(proxyAdmin));
 
         // Deploy implementation
-        MockTaskAVSRegistrar taskAVSRegistrarImpl = new MockTaskAVSRegistrar(ALLOCATION_MANAGER, KEY_REGISTRAR, PERMISSION_CONTROLLER);
+        MockTaskAVSRegistrar taskAVSRegistrarImpl =
+            new MockTaskAVSRegistrar(ALLOCATION_MANAGER, KEY_REGISTRAR, PERMISSION_CONTROLLER);
         console.log("TaskAVSRegistrar implementation deployed to:", address(taskAVSRegistrarImpl));
 
         // Deploy proxy with initialization


### PR DESCRIPTION
Pulling the latest middleware contract changes which includes the update core contract bindings. This has the change in bindings for the TaskMailbox contract.