### PR TITLE
fix: updating status channel handling for performer

### DIFF
--- a/ponos/pkg/executor/avsPerformer/avsContainerPerformer/containerPerformer.go
+++ b/ponos/pkg/executor/avsPerformer/avsContainerPerformer/containerPerformer.go
@@ -423,8 +423,6 @@ func (aps *AvsContainerPerformer) handleContainerEvent(ctx context.Context, even
 	// Only reach this point if the event indicates an unhealthy container.
 	if targetContainer.statusChan != nil {
 		select {
-		case <-ctx.Done():
-			return
 		case targetContainer.statusChan <- avsPerformer.PerformerStatusEvent{
 			Status:      avsPerformer.PerformerUnhealthy,
 			PerformerID: targetContainer.performerID,


### PR DESCRIPTION
## Overview

A race condition in performer status channel management can cause runtime panics when removing performers during
active health monitoring.
Both Kubernetes and container performer implementations close status channels synchronously in while health monitoring goroutines continue executing independently. The health monitors periodically send status
events to these channels, creating a race condition where writes can occur after channel closure.
RemovePerformer()

## Solution
The solution is to not close the status chan and simply allow it to be garbage collected once the Go routines using it are stopped.